### PR TITLE
feat: deploy Bimo workflows to local hardware

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,20 @@ FROM docker:27.5.1-cli@sha256:851f91d241214e7c6db86513b270d58776379aacc5eb9c4a87
 FROM node:22-slim@sha256:e9bff3a454208b46a1f96da92878cc7f56a2a41ceac2216825be3177736896b5
 
 ARG OPENCODE_VERSION=1.18.22
+ARG TARGETARCH
 
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends ca-certificates git \
     && rm -rf /var/lib/apt/lists/* \
+    && case "${TARGETARCH}" in \
+      amd64) OPENCODE_ARCH=x64 ;; \
+      arm64) OPENCODE_ARCH=arm64 ;; \
+      *) echo "unsupported target architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac \
     && npm install --global --ignore-scripts --omit=optional "opencode-ai@${OPENCODE_VERSION}" \
-    && npm install --global --ignore-scripts "opencode-linux-x64@${OPENCODE_VERSION}" \
+    && npm install --global --ignore-scripts "opencode-linux-${OPENCODE_ARCH}@${OPENCODE_VERSION}" \
     && ln --symbolic --force \
-      /usr/local/lib/node_modules/opencode-linux-x64/bin/opencode \
+      "/usr/local/lib/node_modules/opencode-linux-${OPENCODE_ARCH}/bin/opencode" \
       /usr/local/bin/opencode \
     && test "$(opencode --version)" = "${OPENCODE_VERSION}" \
     && npm cache clean --force

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Bimo v0.4
+# Bimo v0.5
 
-Bimo deploys predefined agent work to one Docker host. v0.4 includes bounded
-sequential workflows, one fixed parallel engineering pod, and up to three
-isolated organizer agents that select the installed template best suited to a
-prompt.
+Bimo deploys predefined agent work to a local or remote Docker-compatible
+target. v0.5 adds a default local target and one closed target seam to the
+bounded sequential workflows, fixed parallel engineering pod, and isolated
+organizer agents introduced in v0.4.
 
 ```text
 template = workflow.json + one Markdown prompt per role
@@ -233,16 +233,16 @@ Controller-owned verification is the separate fixed step described above.
 
 ## Install from GitHub
 
-Bimo is not published to the npm registry. Download the v0.4.0 release
+Bimo is not published to the npm registry. Download the v0.5.0 release
 tarball and checksum, verify the exact file, then install it locally:
 
 ```bash
 curl --fail --location --remote-name \
-  https://github.com/zaycruz/bimo/releases/download/v0.4.0/bimo-workflow-0.4.0.tgz
+  https://github.com/zaycruz/bimo/releases/download/v0.5.0/bimo-workflow-0.5.0.tgz
 curl --fail --location --remote-name \
-  https://github.com/zaycruz/bimo/releases/download/v0.4.0/bimo-workflow-0.4.0.tgz.sha256
-shasum --algorithm 256 --check bimo-workflow-0.4.0.tgz.sha256
-npm install --global ./bimo-workflow-0.4.0.tgz
+  https://github.com/zaycruz/bimo/releases/download/v0.5.0/bimo-workflow-0.5.0.tgz.sha256
+shasum --algorithm 256 --check bimo-workflow-0.5.0.tgz.sha256
+npm install --global ./bimo-workflow-0.5.0.tgz
 bimo list --json
 bimo validate parallel-engineering-pod
 BIMO_PACKAGE_ROOT="$(npm root --global)/bimo-workflow"
@@ -267,10 +267,41 @@ List and validate the installed templates:
 ```bash
 bimo list
 bimo list --json
+bimo targets
+bimo targets --json
 bimo validate react-app
 bimo validate react-solo --json
 bimo validate parallel-engineering-pod --json
 ```
+
+`bimo targets` probes the local Docker daemon and reports the built-in access
+adapters. `local` is automatic and is the default. `ssh` and `proxmox-lxc` are
+configured per command; their `on-demand` status means Bimo has not contacted a
+specific host yet. Local mode uses the active Unix-socket Docker context and
+rejects ambient `DOCKER_HOST` overrides.
+
+### Deploy locally
+
+With Docker available, no target flags are required. On this Mac, for example,
+the `local` adapter uses the active Colima Docker daemon and builds the image for
+the daemon's native `linux/arm64` platform:
+
+```bash
+BIMO_PACKAGE_ROOT="${BIMO_PACKAGE_ROOT:-$(npm root --global)/bimo-workflow}"
+
+bimo deploy react-solo \
+  --deployment solo-local \
+  --task-file "$BIMO_PACKAGE_ROOT/examples/solo-demo.md" \
+  --secret-ref 'op://VAULT/ITEM/OPENROUTER_KEY' \
+  --public-url 'http://127.0.0.1:8080'
+
+bimo logs --deployment solo-local
+```
+
+`--target local` is the equivalent explicit form. Local state lives under
+`~/.local/share/bimo/deployments/<deployment>/`. Local deployment still uses
+Linux containers and a Docker socket; it does not silently substitute macOS
+Seatbelt or Apple's `container` runtime.
 
 ### Organize a prompt with agents
 
@@ -289,8 +320,6 @@ SMALL_APP_ASSIGNMENT="$(<"$SMALL_APP_PROMPT")"
 PLAN="$(bimo -p "$SMALL_APP_ASSIGNMENT" \
   -n 3 \
   --deployment organize-demo \
-  --proxmox pve-05 \
-  --vmid 113 \
   --secret-ref 'op://VAULT/ITEM/OPENROUTER_KEY' \
   --json)"
 
@@ -327,6 +356,7 @@ BASE_SHA="$(git ls-remote --refs "$REPOSITORY" refs/heads/main | cut -f1)"
 POD_PLAN="$(bimo -p "$POD_ASSIGNMENT" \
   -n 3 \
   --deployment pod-plan-demo \
+  --target proxmox-lxc \
   --proxmox root@pve-05 \
   --vmid 113 \
   --secret-ref 'op://VAULT/ITEM/OPENROUTER_KEY' \
@@ -336,6 +366,7 @@ printf '%s\n' "$POD_PLAN" | jq .
 
 bimo deploy parallel-engineering-pod \
   --deployment pod-demo \
+  --target proxmox-lxc \
   --proxmox root@pve-05 \
   --vmid 113 \
   --task-file "$POD_TASK_FILE" \
@@ -371,6 +402,7 @@ LXC_ADDRESS='10.200.160.143' # Replace this when targeting another LXC.
 
 bimo deploy react-app \
   --deployment fleet-demo \
+  --target proxmox-lxc \
   --proxmox root@pve-05 \
   --vmid 113 \
   --task-file "$BIMO_PACKAGE_ROOT/examples/fleet-demo.md" \
@@ -383,6 +415,7 @@ Deploy the sequential one-role template independently:
 ```bash
 bimo deploy react-solo \
   --deployment solo-demo \
+  --target proxmox-lxc \
   --proxmox root@pve-05 \
   --vmid 113 \
   --task-file "$BIMO_PACKAGE_ROOT/examples/solo-demo.md" \
@@ -409,14 +442,14 @@ bimo logs \
 
 ### Deploy to a Docker host
 
-Use `--host` instead of `--proxmox` and `--vmid` when Docker runs directly on
-the SSH target:
+Use `--target ssh --host HOST` when Docker runs directly on the SSH target:
 
 ```bash
 BIMO_PACKAGE_ROOT="${BIMO_PACKAGE_ROOT:-$(npm root --global)/bimo-workflow}"
 
 bimo deploy react-app \
   --deployment fleet-demo \
+  --target ssh \
   --host deploy@docker-host.example \
   --task-file "$BIMO_PACKAGE_ROOT/examples/fleet-demo.md" \
   --secret-ref 'op://VAULT/ITEM/FIELD' \
@@ -427,8 +460,11 @@ bimo logs \
   --host deploy@docker-host.example
 ```
 
-Deploy accepts exactly one target (`--host`, or `--proxmox` with `--vmid`) and
-exactly one task source (`--task-file FILE` or `--task-stdin`). Every deployment
+Deploy defaults to local Docker. The explicit forms are `--target local`,
+`--target ssh --host HOST`, and `--target proxmox-lxc --proxmox HOST --vmid ID`.
+The older `--host` and `--proxmox ... --vmid ...` forms remain aliases. Target
+options cannot be mixed. Deploy also accepts exactly one task source
+(`--task-file FILE` or `--task-stdin`). Every deployment
 requires `--deployment` and `--secret-ref`. Sequential workflows also require
 `--public-url`. The fixed pod instead requires `--github-secret-ref`, the fixed
 repository URL, an immutable `--base-sha`, and `--target-branch main`.
@@ -438,7 +474,7 @@ sequential deploys also accept `--port`. `logs` accepts `--run`, `--image`, and
 `--json`.
 
 Defaults are port `8080`, model `openrouter/deepseek/deepseek-v4-flash`, and
-image tag `bimo-workflow:0.4.0`. `--account` selects a 1Password account;
+image tag `bimo-workflow:0.5.0`. `--account` selects a 1Password account;
 `--json` requests machine-readable output.
 
 Quote each `op://` reference as one shell argument. Vault, item, and field names
@@ -452,7 +488,9 @@ your environment; this repository does not claim a public hosted domain.
 
 ## State and logs
 
-One deployment keeps its state on the target:
+One deployment keeps its state on the target. Remote targets use
+`/var/lib/bimo/deployments/<deployment>/`; local targets use
+`~/.local/share/bimo/deployments/<deployment>/`:
 
 ```text
 /var/lib/bimo/deployments/<deployment>/
@@ -473,7 +511,7 @@ records against target-host root.
 Each successful verification creates a separate artifact snapshot that Bimo
 treats as immutable: it is created once, permission-locked, and mounted by the
 retained app read-only. Bimo performs automatic rollback only when replacing
-the current app fails; v0.4 has no user-facing rollback command or remote
+the current app fails; v0.5 has no user-facing rollback command or remote
 artifact backup.
 
 The fixed pod uses the same deployment root but keeps private run records under
@@ -494,12 +532,13 @@ and private temporary roots. The pod does not resume a partial Planner, writer,
 or checker attempt. Confirm no controller or publisher is active, preserve the
 run records for diagnosis, then recover only that dedicated deployment root
 before starting a new run. The internal publisher can reconcile an interrupted
-durable publication, but v0.4 has no general user-facing resume command.
+durable publication, but v0.5 has no general user-facing resume command.
 
 ## Security boundary
 
-- The OpenRouter key is resolved locally with `op read`, sent through SSH and
-  controller stdin, then sent to a run-scoped credential gateway through stdin.
+- The OpenRouter key is resolved locally with `op read`, sent to the controller
+  through stdin (and over SSH for remote targets), then sent to a run-scoped
+  credential gateway through stdin.
   It is not placed in workflow JSON, prompts, command-line arguments, the shared
   workspace, or role-container environment.
 - Role containers join an internal Docker network with no direct egress. Only
@@ -551,19 +590,25 @@ Never put a credential in a task, prompt, workflow file, repository file,
   workspace.
 - OpenRouter is the only provider. There is no provider discovery, marketplace,
   generic DAG, manager service, inter-agent chat, message bus, or graph runtime.
-- Deployment is Docker over SSH, directly or through Proxmox `pct exec`. There
-  is no Helm, Terraform, Kubernetes scheduler, multi-host placement, HA, or
-  autoscaling layer.
+- Deployment uses the local Docker daemon, Docker over SSH, or Docker inside a
+  Proxmox LXC through `pct exec`. There is no Proxmox API adapter, native Linux
+  LXC lifecycle manager, Apple `container` adapter, Seatbelt runtime, Helm,
+  Terraform, Kubernetes scheduler, multi-host placement, HA, or autoscaling
+  layer.
+- Deployment targets are a closed built-in registry, not executable third-party
+  plugins. Templates remain data-only packs. A plugin ABI would add lifecycle,
+  trust, and compatibility surface before Bimo has a second container runtime
+  that needs it; see [the target boundary](docs/targets.md).
 - Publication serves static files only. Replacement is preflighted and can
   restore the prior app on failure, but zero downtime is not guaranteed.
 - History and artifacts remain on one target host. There is no database, remote
   backup, or user-invoked rollback.
 - Organizer audit runs are retained on the target and are not automatically
-  pruned in v0.4.
+  pruned in v0.5.
 - Pod publication stops at an isolated, draft pull request. It does not approve,
   mark ready, merge, deploy, or delete the branch.
 
-## v0.4 verification
+## v0.5 verification
 
 The release gate runs the full Node test suite, package manifest verification,
 Docker image build, all template validations, and the bundled starter offline

--- a/docs/organize.md
+++ b/docs/organize.md
@@ -17,18 +17,18 @@ is displayed for context but never executed or reused as deployment input.
 Use one selector for the smallest, deterministic path:
 
 ```sh
-bimo organize -p "Build a small React app that displays a task list." -n 1 --deployment organize-demo --proxmox pve-05 --vmid 113 --secret-ref op://VAULT/ITEM/FIELD --json
+bimo organize -p "Build a small React app that displays a task list." -n 1 --deployment organize-demo --secret-ref op://VAULT/ITEM/FIELD --json
 ```
 
 The root shorthand accepts the same prompt without the subcommand:
 
 ```sh
-bimo -p "Build a small React app that displays a task list." -n 1 --deployment organize-demo --proxmox pve-05 --vmid 113 --secret-ref op://VAULT/ITEM/FIELD --json
+bimo -p "Build a small React app that displays a task list." -n 1 --deployment organize-demo --secret-ref op://VAULT/ITEM/FIELD --json
 ```
 
 These values show the complete command shape. Replace the `op://` placeholder
 with an authorized OpenRouter secret reference, and substitute the deployment
-name, target, or VM ID when using another environment. Keep these operational
+name or target when using another environment. Keep these operational
 values in the command boundary only: they are never fields in the selector
 receipt.
 

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -1,0 +1,51 @@
+# Deployment targets
+
+Bimo keeps workflow semantics separate from placement. A template says which
+roles run and how their receipts transition. A deployment target says where the
+same Docker commands execute and where durable run state lives.
+
+The current built-in target set is deliberately closed:
+
+| Target | Command execution | State root | Selection |
+| --- | --- | --- | --- |
+| `local` | Active local Docker context over a Unix socket | `~/.local/share/bimo/deployments/<name>` | Default, or `--target local` |
+| `ssh` | Docker over strict, batch-mode SSH | `/var/lib/bimo/deployments/<name>` | `--target ssh --host HOST` |
+| `proxmox-lxc` | `pct exec VMID -- docker ...` over strict, batch-mode SSH | `/var/lib/bimo/deployments/<name>` in the LXC | `--target proxmox-lxc --proxmox HOST --vmid ID` |
+
+Run `bimo targets` to probe the local daemon and list the command-time adapters.
+The legacy `--host HOST` and `--proxmox HOST --vmid ID` forms still resolve to
+the same `ssh` and `proxmox-lxc` adapters.
+
+Local mode follows the active Docker context and accepts only `linux/amd64` or
+`linux/arm64` daemons exposed through a Unix socket. Bimo rejects ambient
+`DOCKER_HOST` overrides so an inherited shell variable cannot silently redirect
+a local deployment. Remote targets are probed before build, and Bimo builds the
+transferred image for the target daemon's reported architecture.
+
+## The seam
+
+The implementation has four small operations:
+
+1. Resolve one target from exact CLI options.
+2. Convert a trusted argv array into a local process or strict SSH invocation.
+3. Choose the target-visible deployment root.
+4. Prepare or transfer the architecture-matched Bimo image.
+
+Templates and organizer agents cannot choose a target, inject a command, or
+install code. Target authority stays in the operator CLI.
+
+## Why this is not a plugin system yet
+
+There is one execution runtime today: Docker. Local, SSH, and Proxmox-LXC are
+different access paths to that same runtime. Loading arbitrary executable
+plugins now would require a versioned ABI, discovery rules, trust and signing
+policy, secret routing, failure cleanup, and compatibility guarantees without
+adding a new capability.
+
+When a real second runtime is implemented, it should first satisfy the same
+bounded target contract as a built-in adapter. Apple `container`, native Linux
+LXC lifecycle management, and Proxmox API provisioning each have materially
+different image, network, storage, and cleanup semantics; none is represented
+as working until its end-to-end deploy and log path is verified. If two or more
+external adapters then need independent release cycles, the built-in registry
+can become a versioned plugin boundary with evidence instead of speculation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bimo-workflow",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bimo-workflow",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "UNLICENSED",
       "bin": {
         "bimo": "bin/bimo"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bimo-workflow",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Deploy bounded, auditable agent workflows as ephemeral Docker fleets.",
   "license": "UNLICENSED",
   "type": "module",

--- a/src/bimo.mjs
+++ b/src/bimo.mjs
@@ -1,7 +1,10 @@
 import { spawn } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
+import { constants as fsConstants } from "node:fs";
 import {
   lstat,
+  mkdir,
+  open,
   readFile,
   readdir,
 } from "node:fs/promises";
@@ -9,6 +12,13 @@ import path from "node:path";
 import process from "node:process";
 
 import { DockerRuntime } from "./docker-runtime.mjs";
+import {
+  builtInTargetCatalog,
+  commandForTarget,
+  deploymentRootForTarget,
+  isDeploymentHostRoot,
+  resolveDeploymentTarget,
+} from "./deployment-target.mjs";
 import { GitRuntime } from "./git-runtime.mjs";
 import {
   validateOrganizerInput,
@@ -26,7 +36,7 @@ import { loadWorkflow, runWorkflow } from "./workflow.mjs";
 const packageRoot = path.resolve(import.meta.dirname, "..");
 const templateRoot = path.join(packageRoot, "templates");
 const organizerInstructionsPath = path.join(packageRoot, "etc", "organizer", "organizer.md");
-const DEFAULT_IMAGE = "bimo-workflow:0.4.0";
+const DEFAULT_IMAGE = "bimo-workflow:0.5.0";
 const DEFAULT_MODEL = "openrouter/deepseek/deepseek-v4-flash";
 const POD_REPOSITORY = "https://github.com/zaycruz/bimo.git";
 const POD_TARGET_BRANCH = "main";
@@ -35,7 +45,6 @@ const IMAGE_TRANSFER_TIMEOUT_MS = 10 * 60 * 1_000;
 const NAME = /^[a-z][a-z0-9-]{0,31}$/;
 const RUN_ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$/;
 const EXECUTION_ID = /^[a-z0-9][a-z0-9-]{0,63}$/;
-const SSH_TARGET = /^(?:[a-z_][a-z0-9_-]*@)?[A-Za-z0-9](?:[A-Za-z0-9.-]{0,251}[A-Za-z0-9])?$/;
 const IMAGE = /^[A-Za-z0-9][A-Za-z0-9._/@:-]{0,255}$/;
 const SECRET_REF = /^op:\/\/[^/\u0000-\u001f\u007f]{1,255}\/[^/\u0000-\u001f\u007f]{1,255}\/[^/\u0000-\u001f\u007f]{1,255}$/u;
 const SHA256 = /^sha256:[a-f0-9]{64}$/;
@@ -47,13 +56,18 @@ const IMAGE_CONFIG_FIELDS = [
   "Volumes", "Labels", "Healthcheck", "StopSignal", "Shell",
 ];
 const WORKFLOW_DEPLOY_OPTIONS = [
-  "--deployment", "--host", "--proxmox", "--vmid", "--task-file", "--task-stdin",
+  "--deployment", "--target", "--host", "--proxmox", "--vmid", "--task-file", "--task-stdin",
   "--secret-ref", "--public-url", "--port",
 ];
 const POD_DEPLOY_OPTIONS = [
-  "--deployment", "--host", "--proxmox", "--vmid", "--task-file", "--task-stdin",
+  "--deployment", "--target", "--host", "--proxmox", "--vmid", "--task-file", "--task-stdin",
   "--secret-ref", "--github-secret-ref", "--repository", "--base-sha", "--target-branch",
 ];
+const DEPLOYMENT_LAYOUTS = {
+  workflow: ["runs", "workspace"],
+  organizer: ["runs", "worktrees"],
+  pod: ["runs", "source", "worktrees", "snapshots"],
+};
 
 function fail(message) {
   throw new Error(message);
@@ -292,6 +306,44 @@ async function listTemplates() {
   return templates;
 }
 
+async function listDeploymentTargets() {
+  const catalog = builtInTargetCatalog();
+  const local = await inspectLocalDocker();
+  return catalog.map(target => target.kind === "local"
+    ? { ...target, ...local }
+    : { ...target, availability: "on-demand" });
+}
+
+async function inspectLocalDocker() {
+  try {
+    if (process.env.DOCKER_HOST?.trim()) {
+      return { availability: "unavailable", reason: "DOCKER_HOST overrides are not accepted for local targets" };
+    }
+    const endpoint = (await execute("docker", [
+      "context", "inspect", "--format", "{{(index .Endpoints \"docker\").Host}}",
+    ], { timeoutMs: 10_000, maxOutputBytes: 4 * 1024 })).stdout.trim();
+    if (!/^unix:\/\/\/[^\u0000\r\n]+$/u.test(endpoint)) {
+      return { availability: "unavailable", reason: "Docker endpoint is not a local Unix socket" };
+    }
+    const result = await execute("docker", [
+      "version", "--format", "{{.Server.Os}}/{{.Server.Arch}}",
+    ], { timeoutMs: 10_000, maxOutputBytes: 4 * 1024 });
+    const platform = result.stdout.trim();
+    if (!/^linux\/(?:amd64|arm64)$/u.test(platform)) {
+      return { availability: "unavailable", reason: "Docker platform must be linux/amd64 or linux/arm64" };
+    }
+    return { availability: "ready", platform };
+  } catch {
+    return { availability: "unavailable", reason: "Docker is unavailable" };
+  }
+}
+
+async function requireLocalDocker() {
+  const status = await inspectLocalDocker();
+  if (status.availability !== "ready") fail(`local target unavailable: ${status.reason}`);
+  return status;
+}
+
 async function loadOrganizerCatalog() {
   const entries = await readdir(templateRoot, { withFileTypes: true });
   const catalog = [];
@@ -321,38 +373,45 @@ async function loadOrganizerCatalog() {
   return validateTemplateCatalog(catalog);
 }
 
-function target(options) {
-  const proxmox = options.proxmox;
-  const host = options.host;
-  if (Boolean(proxmox) === Boolean(host)) fail("use exactly one of --host or --proxmox");
-  const sshTarget = proxmox ?? host;
-  if (!SSH_TARGET.test(sshTarget)) fail("SSH target contains unsupported characters");
-  if (proxmox) {
-    if (!/^\d{1,9}$/.test(options.vmid ?? "")) fail("--vmid must be numeric with --proxmox");
-    return { sshTarget, prefix: ["pct", "exec", options.vmid, "--"] };
+async function targetExecute(target, command, options) {
+  const invocation = commandForTarget(target, command);
+  return execute(invocation.command, invocation.args, options);
+}
+
+async function targetPlatform(target) {
+  if (target.kind === "local") return (await requireLocalDocker()).platform;
+  const result = await targetExecute(target, [
+    "docker", "version", "--format", "{{.Server.Os}}/{{.Server.Arch}}",
+  ], { timeoutMs: 10_000, maxOutputBytes: 4 * 1024 });
+  const platform = result.stdout.trim();
+  if (!/^linux\/(?:amd64|arm64)$/u.test(platform)) {
+    fail("target Docker platform must be linux/amd64 or linux/arm64");
   }
-  if (options.vmid) fail("--vmid is only valid with --proxmox");
-  return { sshTarget, prefix: [] };
+  return platform;
 }
 
-function sshArgs(remote, command) {
-  return [
-    "-o", "BatchMode=yes",
-    "-o", "StrictHostKeyChecking=yes",
-    remote.sshTarget,
-    ...remote.prefix,
-    ...command,
-  ];
+function deploymentDirectories(layout) {
+  const directories = DEPLOYMENT_LAYOUTS[layout];
+  if (!directories) fail("layout must be workflow, organizer, or pod");
+  return directories;
 }
 
-async function remoteExecute(remote, command, options) {
-  return execute("ssh", sshArgs(remote, command), options);
+function controllerLocalRootArgs(target) {
+  return target.kind === "local" ? ["--local-home", target.home] : [];
 }
 
-function transferImage(remote, image, { timeoutMs = IMAGE_TRANSFER_TIMEOUT_MS } = {}) {
+function controllerHostRootIsValid(hostRoot, deployment, localHome) {
+  return isDeploymentHostRoot(hostRoot, deployment, { localHome });
+}
+
+function transferImage(target, image, { timeoutMs = IMAGE_TRANSFER_TIMEOUT_MS } = {}) {
+  const loadInvocation = commandForTarget(target, ["docker", "load"]);
+  if (target.kind === "local" || loadInvocation.command !== "ssh") {
+    fail("image transfer requires a remote deployment target");
+  }
   return new Promise((resolve, reject) => {
     const save = spawn("docker", ["save", image], { cwd: packageRoot, stdio: ["ignore", "pipe", "pipe"] });
-    const load = spawn("ssh", sshArgs(remote, ["docker", "load"]), { stdio: ["pipe", "pipe", "pipe"] });
+    const load = spawn(loadInvocation.command, loadInvocation.args, { stdio: ["pipe", "pipe", "pipe"] });
     save.stdout.pipe(load.stdin);
     const output = [];
     let outputBytes = 0;
@@ -432,10 +491,20 @@ function imageTransferTag(imageId) {
   return `bimo-transfer:${imageId.slice(7, 19)}-${randomUUID().replaceAll("-", "")}`;
 }
 
-async function prepareRemoteImage(remote, image, { retag = true } = {}) {
-  await execute("docker", ["build", "--platform", "linux/amd64", "--tag", image, packageRoot]);
+async function prepareImage(target, image, { retag = true } = {}) {
+  const platform = await targetPlatform(target);
+  const buildArgs = target.kind === "local"
+    ? ["build", "--tag", image, packageRoot]
+    : ["build", "--platform", platform, "--tag", image, packageRoot];
+  await execute("docker", buildArgs);
   const imageResult = await execute("docker", ["image", "inspect", image]);
   const localImage = parseImageInspect(imageResult.stdout, "local");
+  if (localImage.platform !== platform) {
+    fail(`built image platform ${localImage.platform} does not match target ${platform}`);
+  }
+  if (target.kind === "local") {
+    return { remoteImage: localImage, transferTag: null };
+  }
   const transferTag = imageTransferTag(localImage.imageId);
   let remoteTransferStarted = false;
   try {
@@ -448,28 +517,95 @@ async function prepareRemoteImage(remote, image, { retag = true } = {}) {
     }
 
     remoteTransferStarted = true;
-    await transferImage(remote, transferTag);
-    const remoteImageResult = await remoteExecute(remote, ["docker", "image", "inspect", transferTag]);
+    await transferImage(target, transferTag);
+    const remoteImageResult = await targetExecute(target, ["docker", "image", "inspect", transferTag]);
     const remoteImage = parseImageInspect(remoteImageResult.stdout, "remote");
     if (remoteImage.contentFingerprint !== localImage.contentFingerprint) {
       fail("transferred image content does not match the inspected local image");
     }
     if (retag) {
-      await remoteExecute(remote, ["docker", "image", "tag", transferTag, image], { timeoutMs: 30_000 });
+      await targetExecute(target, ["docker", "image", "tag", transferTag, image], { timeoutMs: 30_000 });
     }
     return { remoteImage, transferTag };
   } catch (error) {
     if (remoteTransferStarted) {
-      await remoteExecute(remote, ["docker", "image", "rm", "-f", transferTag], { timeoutMs: 30_000 }).catch(() => {});
+      await targetExecute(target, ["docker", "image", "rm", "-f", transferTag], { timeoutMs: 30_000 }).catch(() => {});
     }
     await execute("docker", ["image", "rm", "-f", transferTag], { timeoutMs: 30_000 }).catch(() => {});
     throw error;
   }
 }
 
-async function cleanupTransferredImage(remote, transferTag) {
-  await remoteExecute(remote, ["docker", "image", "rm", "-f", transferTag], { timeoutMs: 30_000 }).catch(() => {});
+async function cleanupTransferredImage(target, transferTag) {
+  if (!transferTag) return;
+  await targetExecute(target, ["docker", "image", "rm", "-f", transferTag], { timeoutMs: 30_000 }).catch(() => {});
   await execute("docker", ["image", "rm", "-f", transferTag], { timeoutMs: 30_000 }).catch(() => {});
+}
+
+async function validateLocalStateChain(home, hostRoot, { allowMissing }) {
+  const relative = path.relative(home, hostRoot);
+  if (!relative || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    fail("local deployment state root is invalid");
+  }
+  let current = home;
+  for (const component of ["", ...relative.split(path.sep)]) {
+    if (component) current = path.join(current, component);
+    let stat;
+    try {
+      stat = await lstat(current);
+    } catch (error) {
+      if (allowMissing && error?.code === "ENOENT") return;
+      fail("local deployment state path is invalid");
+    }
+    if (!stat.isDirectory() || stat.isSymbolicLink()) {
+      fail("local deployment state path must contain only real directories");
+    }
+  }
+}
+
+async function ensureLocalStateRoot(target, hostRoot) {
+  await validateLocalStateChain(target.home, hostRoot, { allowMissing: true });
+  await mkdir(hostRoot, { recursive: true, mode: 0o700 });
+  await validateLocalStateChain(target.home, hostRoot, { allowMissing: false });
+}
+
+async function prepareLocalState(target, image, hostRoot, layout) {
+  if (target.kind !== "local") fail("local state preparation requires the local target");
+  deploymentDirectories(layout);
+  await ensureLocalStateRoot(target, hostRoot);
+  await targetExecute(target, [
+    "docker", "run", "--rm",
+    "--user", "0:0",
+    "--network", "none",
+    "--read-only",
+    "--cap-drop", "ALL",
+    "--cap-add", "CHOWN",
+    "--cap-add", "DAC_OVERRIDE",
+    "--cap-add", "FOWNER",
+    "--security-opt", "no-new-privileges",
+    "--pids-limit", "32",
+    "--memory", "64m",
+    "--cpus", "0.25",
+    "--volume", `${hostRoot}:/deployment:rw`,
+    image,
+    "internal-prepare",
+    "--layout", layout,
+  ], { timeoutMs: 30_000, maxOutputBytes: 16 * 1024 });
+}
+
+async function prepareDeploymentState(target, image, hostRoot, layout) {
+  const directories = deploymentDirectories(layout);
+  if (target.kind === "local") {
+    await prepareLocalState(target, image, hostRoot, layout);
+    return;
+  }
+  const paths = directories.map(directory => `${hostRoot}/${directory}`);
+  await targetExecute(target, ["mkdir", "-p", ...paths]);
+  await targetExecute(target, ["chmod", "700", hostRoot, ...paths]);
+  if (layout === "workflow") {
+    await targetExecute(target, ["chown", "1000:0", `${hostRoot}/workspace`]);
+    await targetExecute(target, ["chmod", "770", `${hostRoot}/workspace`]);
+  }
 }
 
 function isPlainObject(value) {
@@ -520,6 +656,7 @@ function parseImageInspect(raw, label) {
   };
   return {
     imageId: value.Id,
+    platform: `${value.Os}/${value.Architecture}`,
     contentFingerprint: createHash("sha256").update(canonicalJson(content)).digest("hex"),
   };
 }
@@ -640,15 +777,15 @@ async function deploy(template, options) {
   const loaded = await loadTemplate(template);
   const pod = loaded.kind === "engineering-pod";
   exactOptions(options, pod ? [
-    "deployment", "proxmox", "host", "vmid", "task-file", "task-stdin",
+    "deployment", "target", "proxmox", "host", "vmid", "task-file", "task-stdin",
     "secret-ref", "github-secret-ref", "account", "repository", "base-sha",
     "target-branch", "model", "image", "json",
   ] : [
-    "deployment", "proxmox", "host", "vmid", "task-file", "task-stdin",
+    "deployment", "target", "proxmox", "host", "vmid", "task-file", "task-stdin",
     "secret-ref", "account", "public-url", "port", "model", "image", "json",
   ]);
   if (!NAME.test(options.deployment ?? "")) fail("--deployment must use lowercase letters, numbers, and dashes");
-  const remote = target(options);
+  const deploymentTarget = resolveDeploymentTarget(options);
   const image = options.image ?? DEFAULT_IMAGE;
   if (!IMAGE.test(image)) fail("--image is invalid");
   const model = options.model ?? DEFAULT_MODEL;
@@ -674,18 +811,11 @@ async function deploy(template, options) {
   if (!task.trim() || Buffer.byteLength(task) > 64 * 1024) fail("task must contain 1 to 65536 bytes");
   if (!options["secret-ref"]) fail("--secret-ref is required");
 
-  const { remoteImage, transferTag } = await prepareRemoteImage(remote, image);
+  const { remoteImage, transferTag } = await prepareImage(deploymentTarget, image);
   try {
-    const hostRoot = `/var/lib/bimo/deployments/${options.deployment}`;
+    const hostRoot = deploymentRootForTarget(deploymentTarget, options.deployment);
     if (pod) {
-      await remoteExecute(remote, [
-        "mkdir", "-p", `${hostRoot}/runs`, `${hostRoot}/source`,
-        `${hostRoot}/worktrees`, `${hostRoot}/snapshots`,
-      ]);
-      await remoteExecute(remote, [
-        "chmod", "700", hostRoot, `${hostRoot}/runs`, `${hostRoot}/source`,
-        `${hostRoot}/worktrees`, `${hostRoot}/snapshots`,
-      ]);
+      await prepareDeploymentState(deploymentTarget, remoteImage.imageId, hostRoot, "pod");
       const runId = `${new Date().toISOString().replace(/[-:.TZ]/g, "").slice(0, 14)}-${randomUUID().slice(0, 8)}`;
       let openRouterKey = await resolveSecret(options["secret-ref"], options.account);
       const computeEnvelope = JSON.stringify({
@@ -704,7 +834,7 @@ async function deploy(template, options) {
       });
       openRouterKey = "";
       const controllerName = `bimo-${options.deployment}-controller`;
-      const compute = await remoteExecute(remote, [
+      const compute = await targetExecute(deploymentTarget, [
         "docker", "run", "--rm", "-i",
         "--name", controllerName,
         "--user", "0:0",
@@ -724,6 +854,7 @@ async function deploy(template, options) {
         remoteImage.imageId,
         "internal-pod-run",
         "--host-root", hostRoot,
+        ...controllerLocalRootArgs(deploymentTarget),
       ], {
         input: computeEnvelope,
         timeoutMs: (loaded.template.timeouts.workflowSeconds + 600) * 1_000,
@@ -746,7 +877,7 @@ async function deploy(template, options) {
         token: githubToken,
       });
       githubToken = "";
-      const publisher = await remoteExecute(remote, [
+      const publisher = await targetExecute(deploymentTarget, [
         "docker", "run", "--rm", "-i",
         "--name", `bimo-${options.deployment}-publisher`,
         "--user", "0:0",
@@ -773,10 +904,7 @@ async function deploy(template, options) {
         `deployed ${loaded.template.name} as ${options.deployment}\nrun: ${response.runId}\nPR: ${response.publication.url} (draft)\n`,
       );
     } else {
-      await remoteExecute(remote, ["mkdir", "-p", `${hostRoot}/runs`, `${hostRoot}/workspace`]);
-      await remoteExecute(remote, ["chmod", "700", hostRoot, `${hostRoot}/runs`]);
-      await remoteExecute(remote, ["chown", "1000:0", `${hostRoot}/workspace`]);
-      await remoteExecute(remote, ["chmod", "770", `${hostRoot}/workspace`]);
+      await prepareDeploymentState(deploymentTarget, remoteImage.imageId, hostRoot, "workflow");
 
       const secret = await resolveSecret(options["secret-ref"], options.account);
       const envelope = JSON.stringify({
@@ -792,7 +920,7 @@ async function deploy(template, options) {
         publicUrl: publicUrl.toString().replace(/\/$/, ""),
       });
       const controllerName = `bimo-${options.deployment}-controller`;
-      const result = await remoteExecute(remote, [
+      const result = await targetExecute(deploymentTarget, [
         "docker", "run", "--rm", "-i",
         "--name", controllerName,
         "--user", "0:0",
@@ -809,6 +937,7 @@ async function deploy(template, options) {
         remoteImage.imageId,
         "internal-run",
         "--host-root", hostRoot,
+        ...controllerLocalRootArgs(deploymentTarget),
       ], {
         input: envelope,
         timeoutMs: (loaded.workflow.timeouts.workflowSeconds + 600) * 1_000,
@@ -819,19 +948,19 @@ async function deploy(template, options) {
       else process.stdout.write(`deployed ${response.template} as ${response.deployment}\nrun: ${response.runId}\nurl: ${response.url}\n`);
     }
   } finally {
-    await cleanupTransferredImage(remote, transferTag);
+    await cleanupTransferredImage(deploymentTarget, transferTag);
   }
 }
 
 async function organizeRemote(options) {
   exactOptions(options, [
-    "prompt", "agents", "deployment", "proxmox", "host", "vmid",
+    "prompt", "agents", "deployment", "target", "proxmox", "host", "vmid",
     "secret-ref", "account", "model", "image", "json",
   ]);
   if (!NAME.test(options.deployment ?? "")) {
     fail("--deployment must use lowercase letters, numbers, and dashes");
   }
-  const remote = target(options);
+  const deploymentTarget = resolveDeploymentTarget(options);
   const prompt = validateOrganizerPrompt(options.prompt);
   const agentsText = options.agents ?? "1";
   if (!/^[1-3]$/u.test(agentsText)) fail("--agents must be an integer from 1 to 3");
@@ -844,11 +973,10 @@ async function organizeRemote(options) {
   const catalog = await loadOrganizerCatalog();
   validateOrganizerInput({ prompt, agents, catalog });
 
-  const { remoteImage, transferTag } = await prepareRemoteImage(remote, image, { retag: false });
+  const { remoteImage, transferTag } = await prepareImage(deploymentTarget, image, { retag: false });
   try {
-    const hostRoot = `/var/lib/bimo/deployments/${options.deployment}`;
-    await remoteExecute(remote, ["mkdir", "-p", `${hostRoot}/runs`, `${hostRoot}/worktrees`]);
-    await remoteExecute(remote, ["chmod", "700", hostRoot, `${hostRoot}/runs`, `${hostRoot}/worktrees`]);
+    const hostRoot = deploymentRootForTarget(deploymentTarget, options.deployment);
+    await prepareDeploymentState(deploymentTarget, remoteImage.imageId, hostRoot, "organizer");
     const runId = `${new Date().toISOString().replace(/[-:.TZ]/g, "").slice(0, 14)}-${randomUUID().slice(0, 8)}`;
     let openRouterKey = await resolveSecret(options["secret-ref"], options.account);
     const envelope = JSON.stringify({
@@ -862,7 +990,7 @@ async function organizeRemote(options) {
       image: remoteImage.imageId,
     });
     openRouterKey = "";
-    const result = await remoteExecute(remote, [
+    const result = await targetExecute(deploymentTarget, [
       "docker", "run", "--rm", "-i",
       "--name", `bimo-${options.deployment}-controller`,
       "--user", "0:0",
@@ -879,6 +1007,7 @@ async function organizeRemote(options) {
       remoteImage.imageId,
       "internal-organize",
       "--host-root", hostRoot,
+      ...controllerLocalRootArgs(deploymentTarget),
     ], {
       input: envelope,
       timeoutMs: 12 * 60 * 1_000,
@@ -900,7 +1029,7 @@ async function organizeRemote(options) {
       "",
     ].join("\n"));
   } finally {
-    await cleanupTransferredImage(remote, transferTag);
+    await cleanupTransferredImage(deploymentTarget, transferTag);
   }
 }
 
@@ -1037,8 +1166,7 @@ export async function runPodController({
 }
 
 async function internalRun(options) {
-  exactOptions(options, ["host-root"]);
-  if (!/^\/var\/lib\/bimo\/deployments\/[a-z][a-z0-9-]{0,31}$/.test(options["host-root"] ?? "")) fail("--host-root is invalid");
+  exactOptions(options, ["host-root", "local-home"]);
   const raw = await readStdin(128 * 1024);
   let envelope;
   try { envelope = JSON.parse(raw); } catch { fail("invalid controller envelope"); }
@@ -1049,6 +1177,7 @@ async function internalRun(options) {
     fail("controller envelope has unexpected fields");
   }
   if (envelope.version !== 1 || !NAME.test(envelope.deployment ?? "") || !NAME.test(envelope.template ?? "")
+      || !controllerHostRootIsValid(options["host-root"], envelope.deployment, options["local-home"])
       || !TEMPLATE_DIGEST.test(envelope.templateDigest ?? "") || !SHA256.test(envelope.image ?? "")) {
     fail("controller envelope is invalid");
   }
@@ -1058,6 +1187,7 @@ async function internalRun(options) {
     image: envelope.image,
     deployment: envelope.deployment,
     hostRoot: options["host-root"],
+    localHome: options["local-home"],
     key: envelope.key,
     model: envelope.model,
     port: envelope.port,
@@ -1075,16 +1205,51 @@ async function readJsonEnvelope(maximumBytes, fields, label) {
   return exactObject(envelope, fields, `${label} envelope`);
 }
 
-async function internalOrganize(options) {
-  exactOptions(options, ["host-root"]);
-  if (!/^\/var\/lib\/bimo\/deployments\/[a-z][a-z0-9-]{0,31}$/.test(options["host-root"] ?? "")) {
-    fail("--host-root is invalid");
+async function openDeploymentDirectory(targetPath, label, { create = false } = {}) {
+  if (create) {
+    try {
+      await mkdir(targetPath, { mode: 0o700 });
+    } catch (error) {
+      if (error?.code !== "EEXIST") fail(`deployment state ${label} is invalid`);
+    }
   }
+  try {
+    return await open(targetPath,
+      fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW);
+  } catch {
+    fail(`deployment state ${label} is invalid`);
+  }
+}
+
+async function internalPrepare(options) {
+  exactOptions(options, ["layout"]);
+  const directories = deploymentDirectories(options.layout);
+  const root = "/deployment";
+  const rootHandle = await openDeploymentDirectory(root, "mount");
+  try {
+    await rootHandle.chmod(0o700);
+  } finally {
+    await rootHandle.close();
+  }
+  for (const directory of directories) {
+    const targetPath = path.join(root, directory);
+    const handle = await openDeploymentDirectory(targetPath, directory, { create: true });
+    try {
+      await handle.chmod(directory === "workspace" ? 0o770 : 0o700);
+      if (directory === "workspace") await handle.chown(1_000, 0);
+    } finally {
+      await handle.close();
+    }
+  }
+}
+
+async function internalOrganize(options) {
+  exactOptions(options, ["host-root", "local-home"]);
   const envelope = await readJsonEnvelope(128 * 1024, [
     "version", "deployment", "runId", "prompt", "agents", "key", "model", "image",
   ], "organizer controller");
   if (envelope.version !== 1 || !NAME.test(envelope.deployment ?? "")
-      || options["host-root"] !== `/var/lib/bimo/deployments/${envelope.deployment}`
+      || !controllerHostRootIsValid(options["host-root"], envelope.deployment, options["local-home"])
       || !RUN_ID.test(envelope.runId ?? "")
       || !Number.isInteger(envelope.agents) || envelope.agents < 1 || envelope.agents > 3
       || !/^sk-or-v1-[A-Za-z0-9_-]{32,}$/.test(envelope.key ?? "")
@@ -1104,6 +1269,7 @@ async function internalOrganize(options) {
     image: envelope.image,
     deployment: envelope.deployment,
     hostRoot: options["host-root"],
+    localHome: options["local-home"],
     key: envelope.key,
     model: envelope.model,
     modelConcurrency: envelope.agents,
@@ -1123,16 +1289,13 @@ async function internalOrganize(options) {
 }
 
 async function internalPodRun(options) {
-  exactOptions(options, ["host-root"]);
-  if (!/^\/var\/lib\/bimo\/deployments\/[a-z][a-z0-9-]{0,31}$/.test(options["host-root"] ?? "")) {
-    fail("--host-root is invalid");
-  }
+  exactOptions(options, ["host-root", "local-home"]);
   const envelope = await readJsonEnvelope(128 * 1024, [
     "version", "template", "templateDigest", "deployment", "task", "key", "model", "image",
     "repository", "baseSha", "targetBranch", "runId",
   ], "pod controller");
   if (envelope.version !== 1 || !NAME.test(envelope.deployment ?? "")
-      || options["host-root"] !== `/var/lib/bimo/deployments/${envelope.deployment}`
+      || !controllerHostRootIsValid(options["host-root"], envelope.deployment, options["local-home"])
       || envelope.template !== "parallel-engineering-pod"
       || !TEMPLATE_DIGEST.test(envelope.templateDigest ?? "")
       || typeof envelope.task !== "string" || !envelope.task.trim()
@@ -1174,6 +1337,7 @@ async function internalPodRun(options) {
     image: envelope.image,
     deployment: envelope.deployment,
     hostRoot: options["host-root"],
+    localHome: options["local-home"],
     key: envelope.key,
     model: envelope.model,
     modelConcurrency: Object.keys(loaded.template.writers).length,
@@ -1236,15 +1400,16 @@ async function internalPublish(options) {
 }
 
 async function remoteLogs(options) {
-  exactOptions(options, ["deployment", "proxmox", "host", "vmid", "run", "image", "json"]);
+  exactOptions(options, ["deployment", "target", "proxmox", "host", "vmid", "run", "image", "json"]);
   if (!NAME.test(options.deployment ?? "")) fail("--deployment is invalid");
   const runId = options.run ?? "latest";
   if (runId !== "latest" && !RUN_ID.test(runId)) fail("--run is invalid");
-  const remote = target(options);
+  const deploymentTarget = resolveDeploymentTarget(options);
+  if (deploymentTarget.kind === "local") await requireLocalDocker();
   const image = options.image ?? DEFAULT_IMAGE;
   if (!IMAGE.test(image)) fail("--image is invalid");
-  const hostRoot = `/var/lib/bimo/deployments/${options.deployment}`;
-  const result = await remoteExecute(remote, [
+  const hostRoot = deploymentRootForTarget(deploymentTarget, options.deployment);
+  const result = await targetExecute(deploymentTarget, [
     "docker", "run", "--rm", "--read-only", "--network", "none",
     "--user", "0:0",
     "--cap-drop", "ALL",
@@ -1280,12 +1445,13 @@ async function internalLogs(argv) {
 function usage() {
   return `usage:
   bimo list [--json]
+  bimo targets [--json]
   bimo validate TEMPLATE [--json]
-  bimo organize -p PROMPT [-n 1|2|3] --deployment NAME (--host HOST | --proxmox HOST --vmid ID) --secret-ref op://VAULT/ITEM/FIELD [--json]
-  bimo -p PROMPT [-n 1|2|3] --deployment NAME (--host HOST | --proxmox HOST --vmid ID) --secret-ref op://VAULT/ITEM/FIELD [--json]
-  bimo deploy TEMPLATE --deployment NAME (--host HOST | --proxmox HOST --vmid ID) --task-file FILE --secret-ref op://VAULT/ITEM/FIELD --public-url URL [--json]
-  bimo deploy parallel-engineering-pod --deployment NAME (--host HOST | --proxmox HOST --vmid ID) --task-file FILE --secret-ref op://VAULT/ITEM/FIELD --github-secret-ref op://VAULT/ITEM/FIELD --repository ${POD_REPOSITORY} --base-sha SHA --target-branch main [--json]
-  bimo logs --deployment NAME (--host HOST | --proxmox HOST --vmid ID) [--run ID] [--json]
+  bimo organize -p PROMPT [-n 1|2|3] --deployment NAME [--target local | --target ssh --host HOST | --target proxmox-lxc --proxmox HOST --vmid ID] --secret-ref op://VAULT/ITEM/FIELD [--json]
+  bimo -p PROMPT [-n 1|2|3] --deployment NAME [--target local | --target ssh --host HOST | --target proxmox-lxc --proxmox HOST --vmid ID] --secret-ref op://VAULT/ITEM/FIELD [--json]
+  bimo deploy TEMPLATE --deployment NAME [--target local | --target ssh --host HOST | --target proxmox-lxc --proxmox HOST --vmid ID] --task-file FILE --secret-ref op://VAULT/ITEM/FIELD --public-url URL [--json]
+  bimo deploy parallel-engineering-pod --deployment NAME [--target local | --target ssh --host HOST | --target proxmox-lxc --proxmox HOST --vmid ID] --task-file FILE --secret-ref op://VAULT/ITEM/FIELD --github-secret-ref op://VAULT/ITEM/FIELD --repository ${POD_REPOSITORY} --base-sha SHA --target-branch main [--json]
+  bimo logs --deployment NAME [--target local | --target ssh --host HOST | --target proxmox-lxc --proxmox HOST --vmid ID] [--run ID] [--json]
 `;
 }
 
@@ -1306,6 +1472,21 @@ export async function main(argv = process.argv.slice(2)) {
     const templates = await listTemplates();
     if (options.json) process.stdout.write(`${JSON.stringify({ templates })}\n`);
     else templates.forEach(template => process.stdout.write(`${template.name}\t${template.roles.join(" -> ")}\n`));
+    return;
+  }
+  if (command === "targets") {
+    const { positional, options } = parseOptions(rest, { booleans: ["json"] });
+    if (positional.length) fail("targets accepts no positional arguments");
+    exactOptions(options, ["json"]);
+    const targets = await listDeploymentTargets();
+    if (options.json) process.stdout.write(`${JSON.stringify({ targets })}\n`);
+    else targets.forEach(target => process.stdout.write([
+      target.kind,
+      target.availability,
+      target.runtime,
+      target.platform ?? "-",
+      target.configuration,
+    ].join("\t") + "\n"));
     return;
   }
   if (command === "validate") {
@@ -1339,6 +1520,12 @@ export async function main(argv = process.argv.slice(2)) {
     const { positional, options } = parseOptions(rest);
     if (positional.length) fail("internal-run accepts no positional arguments");
     await internalRun(options);
+    return;
+  }
+  if (command === "internal-prepare") {
+    const { positional, options } = parseOptions(rest);
+    if (positional.length) fail("internal-prepare accepts no positional arguments");
+    await internalPrepare(options);
     return;
   }
   if (command === "internal-organize") {

--- a/src/deployment-target.mjs
+++ b/src/deployment-target.mjs
@@ -1,0 +1,140 @@
+import { realpathSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const NAME = /^[a-z][a-z0-9-]{0,31}$/;
+const SSH_TARGET = /^(?:[a-z_][a-z0-9_-]*@)?[A-Za-z0-9](?:[A-Za-z0-9.-]{0,251}[A-Za-z0-9])?$/;
+const TARGET_KINDS = ["local", "ssh", "proxmox-lxc"];
+const REMOTE_ROOT = "/var/lib/bimo/deployments";
+const LOCAL_ROOT_PARTS = [".local", "share", "bimo", "deployments"];
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function validateSshTarget(value) {
+  if (!SSH_TARGET.test(value ?? "")) fail("SSH target contains unsupported characters");
+  return value;
+}
+
+function validateLocalHome(home) {
+  if (typeof home !== "string" || home.length > 4_096 || !path.isAbsolute(home)
+      || path.normalize(home) !== home || /[\u0000\r\n]/u.test(home)) {
+    fail("local home directory must be canonical and absolute");
+  }
+  return home;
+}
+
+function resolveLocalHome(home) {
+  const validated = validateLocalHome(home);
+  let resolved;
+  try {
+    resolved = realpathSync.native(validated);
+  } catch {
+    fail("local home directory must exist");
+  }
+  if (resolved !== validated) fail("local home directory must not be a symlink");
+  return validated;
+}
+
+export function resolveDeploymentTarget(options = {}, { home = os.homedir() } = {}) {
+  const requested = options.target;
+  const hasHost = Object.hasOwn(options, "host");
+  const hasProxmox = Object.hasOwn(options, "proxmox");
+  const hasVmid = Object.hasOwn(options, "vmid");
+  if (requested !== undefined && !TARGET_KINDS.includes(requested)) {
+    fail("--target must be local, ssh, or proxmox-lxc");
+  }
+
+  if (!requested && hasHost && hasProxmox) fail("use only one target");
+  const kind = requested
+    ?? (hasHost ? "ssh" : hasProxmox ? "proxmox-lxc" : "local");
+
+  if (kind === "local") {
+    if (hasHost) fail("--host is not valid with --target local");
+    if (hasProxmox) fail("--proxmox is not valid with --target local");
+    if (hasVmid) fail("--vmid is only valid with --target proxmox-lxc");
+    return Object.freeze({ kind, runtime: "docker", home: resolveLocalHome(home) });
+  }
+
+  if (kind === "ssh") {
+    if (!hasHost || !options.host) fail("--host is required with --target ssh");
+    if (hasProxmox) fail("--proxmox is only valid with --target proxmox-lxc");
+    if (hasVmid) fail("--vmid is only valid with --target proxmox-lxc");
+    return Object.freeze({
+      kind,
+      runtime: "docker",
+      sshTarget: validateSshTarget(options.host),
+    });
+  }
+
+  if (hasHost) fail("--host is only valid with --target ssh");
+  if (!hasProxmox || !options.proxmox) fail("--proxmox is required with --target proxmox-lxc");
+  validateSshTarget(options.proxmox);
+  if (!/^\d{1,9}$/.test(options.vmid ?? "")) fail("--vmid must be numeric with --proxmox");
+  return Object.freeze({
+    kind,
+    runtime: "docker",
+    sshTarget: options.proxmox,
+    vmid: options.vmid,
+  });
+}
+
+export function commandForTarget(target, command) {
+  if (!target || !TARGET_KINDS.includes(target.kind)
+      || !Array.isArray(command) || command.length < 1
+      || command.some(value => typeof value !== "string" || !value)) {
+    fail("invalid deployment target command");
+  }
+  if (target.kind === "local") {
+    return { command: command[0], args: command.slice(1) };
+  }
+  const prefix = target.kind === "proxmox-lxc"
+    ? ["pct", "exec", target.vmid, "--"]
+    : [];
+  return {
+    command: "ssh",
+    args: [
+      "-o", "BatchMode=yes",
+      "-o", "StrictHostKeyChecking=yes",
+      target.sshTarget,
+      ...prefix,
+      ...command,
+    ],
+  };
+}
+
+export function deploymentRootForTarget(target, deployment) {
+  if (!target || !TARGET_KINDS.includes(target.kind) || !NAME.test(deployment ?? "")) {
+    fail("invalid deployment target root");
+  }
+  if (target.kind !== "local") return `${REMOTE_ROOT}/${deployment}`;
+  return path.join(validateLocalHome(target.home ?? os.homedir()), ...LOCAL_ROOT_PARTS, deployment);
+}
+
+export function isDeploymentHostRoot(hostRoot, deployment, { localHome } = {}) {
+  if (typeof hostRoot !== "string" || hostRoot.length > 4_096
+      || !NAME.test(deployment ?? "") || !path.isAbsolute(hostRoot)
+      || path.normalize(hostRoot) !== hostRoot || /[\u0000\r\n]/u.test(hostRoot)) {
+    return false;
+  }
+  if (hostRoot === `${REMOTE_ROOT}/${deployment}`) return true;
+  if (localHome === undefined) return false;
+  try {
+    return hostRoot === deploymentRootForTarget({ kind: "local", home: localHome }, deployment);
+  } catch {
+    return false;
+  }
+}
+
+export function builtInTargetCatalog() {
+  return Object.freeze([
+    Object.freeze({ kind: "local", runtime: "docker", configuration: "automatic" }),
+    Object.freeze({ kind: "ssh", runtime: "docker", configuration: "--host HOST" }),
+    Object.freeze({
+      kind: "proxmox-lxc",
+      runtime: "docker",
+      configuration: "--proxmox HOST --vmid ID",
+    }),
+  ]);
+}

--- a/src/docker-runtime.mjs
+++ b/src/docker-runtime.mjs
@@ -14,9 +14,10 @@ import {
 } from "node:fs/promises";
 import path from "node:path";
 
+import { isDeploymentHostRoot } from "./deployment-target.mjs";
+
 const NAME = /^[a-z][a-z0-9-]{0,31}$/;
 const MODEL = /^openrouter\/[a-z0-9][a-z0-9._/-]{2,127}$/;
-const HOST_ROOT = /^\/var\/lib\/bimo\/deployments\/[a-z][a-z0-9-]{0,31}$/;
 const SAFE_IMAGE = /^[A-Za-z0-9][A-Za-z0-9._/@:-]{0,255}$/;
 const RUN_ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$/;
 const EXECUTION_ID = /^[a-z0-9][a-z0-9-]{0,63}$/;
@@ -347,6 +348,8 @@ export function proxyCreateArgs({
 
 export function sourceVerifierCreateArgs({
   deployment,
+  hostRoot,
+  localHome,
   image,
   snapshotHost,
   baselineTestHost,
@@ -361,7 +364,10 @@ export function sourceVerifierCreateArgs({
     fail("invalid source verifier identity");
   }
   if (!SAFE_IMAGE.test(image ?? "")) fail("invalid source verifier image");
-  const snapshotRoot = path.join("/var/lib/bimo/deployments", deployment, "snapshots");
+  if (!isDeploymentHostRoot(hostRoot, deployment, { localHome })) {
+    fail("invalid source verifier host root");
+  }
+  const snapshotRoot = path.join(hostRoot, "snapshots");
   if (typeof snapshotHost !== "string" || !path.isAbsolute(snapshotHost)
       || !path.resolve(snapshotHost).startsWith(`${snapshotRoot}${path.sep}`)) {
     fail("invalid source snapshot host path");
@@ -784,6 +790,7 @@ export class DockerRuntime {
     image,
     deployment,
     hostRoot,
+    localHome,
     stateRoot = "/state",
     key,
     model,
@@ -793,8 +800,7 @@ export class DockerRuntime {
     publicUrl,
   }) {
     if (!NAME.test(deployment)) fail("invalid deployment name");
-    if (!HOST_ROOT.test(hostRoot)) fail("invalid Bimo host root");
-    if (hostRoot !== `/var/lib/bimo/deployments/${deployment}`) {
+    if (!isDeploymentHostRoot(hostRoot, deployment, { localHome })) {
       fail("Bimo host root must match deployment");
     }
     if (typeof stateRoot !== "string" || !path.isAbsolute(stateRoot)) fail("invalid Bimo state root");
@@ -826,6 +832,7 @@ export class DockerRuntime {
     this.image = image;
     this.deployment = deployment;
     this.hostRoot = hostRoot;
+    this.localHome = localHome;
     this.stateRoot = path.resolve(stateRoot);
     this.key = key;
     this.model = model;
@@ -1266,6 +1273,8 @@ export class DockerRuntime {
       try {
         const created = await this.commandWithin(sourceVerifierCreateArgs({
           deployment: this.deployment,
+          hostRoot: this.hostRoot,
+          localHome: this.localHome,
           image: this.image,
           snapshotHost: candidateHost,
           ...(suite === "baseline" ? { baselineTestHost: baselineTestsHost } : {}),

--- a/test/brand.test.mjs
+++ b/test/brand.test.mjs
@@ -30,7 +30,7 @@ test("publishes the clean-break Bimo product contract", async () => {
   const packageJson = JSON.parse(await readFile(path.join(root, "package.json"), "utf8"));
 
   assert.equal(packageJson.name, "bimo-workflow");
-  assert.equal(packageJson.version, "0.4.0");
+  assert.equal(packageJson.version, "0.5.0");
   assert.deepEqual(packageJson.bin, { bimo: "bin/bimo" });
   assert.equal(packageJson.repository.url, "git+https://github.com/zaycruz/bimo.git");
   assert.equal(packageJson.homepage, "https://github.com/zaycruz/bimo#readme");

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -3,6 +3,7 @@ import { execFile, spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { EventEmitter } from "node:events";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
 import { tmpdir } from "node:os";
 import { promisify } from "node:util";
 import path from "node:path";
@@ -81,10 +82,14 @@ const REORDERED_CONFIG = {
 };
 const BASE_LAYERS = [`sha256:${"c".repeat(64)}`, `sha256:${"d".repeat(64)}`];
 
-function imageInspect(imageId, { config = BASE_CONFIG, layers = BASE_LAYERS } = {}) {
+function imageInspect(imageId, {
+  architecture = "amd64",
+  config = BASE_CONFIG,
+  layers = BASE_LAYERS,
+} = {}) {
   return JSON.stringify([{
     Id: imageId,
-    Architecture: "amd64",
+    Architecture: architecture,
     Os: "linux",
     Config: config,
     RootFS: { Type: "layers", Layers: layers },
@@ -95,6 +100,8 @@ async function fakeDeployTools(t, {
   remoteImageId = REMOTE_IMAGE_ID,
   remoteConfig = REORDERED_CONFIG,
   remoteLayers = BASE_LAYERS,
+  remotePlatform = "linux/amd64",
+  localArchitecture = "amd64",
   controller = "conflict",
 } = {}) {
   const directory = await mkdtemp(path.join(tmpdir(), "bimo-cli-test-"));
@@ -103,26 +110,60 @@ async function fakeDeployTools(t, {
   await writeFile(logFile, "");
   await writeFile(taskFile, "Build the test application.\n");
 
-  const docker = `#!/usr/bin/env node
+const docker = `#!/usr/bin/env node
 const fs = require("node:fs");
 const args = process.argv.slice(2);
 fs.appendFileSync(process.env.BIMO_TEST_LOG, JSON.stringify({ tool: "docker", args }) + "\\n");
-if (args[0] === "image" && args[1] === "inspect") process.stdout.write(process.env.BIMO_TEST_LOCAL_INSPECT + "\\n");
+const log = value => fs.appendFileSync(process.env.BIMO_TEST_LOG, JSON.stringify(value) + "\\n");
+if (args[0] === "context" && args[1] === "inspect") process.stdout.write(process.env.BIMO_TEST_DOCKER_ENDPOINT + "\\n");
+else if (args[0] === "version") process.stdout.write("linux/arm64\\n");
+else if (args[0] === "image" && args[1] === "inspect") process.stdout.write(process.env.BIMO_TEST_LOCAL_INSPECT + "\\n");
 else if (args[0] === "save") process.stdout.write("fake-image-archive");
+else if (args[0] === "run") {
+  const internalCommand = args.find(value => value === "internal-prepare" || value === "internal-run");
+  if (internalCommand === "internal-prepare") process.stdout.write("prepared\\n");
+  else {
+    let raw = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", chunk => { raw += chunk; });
+    process.stdin.on("end", () => {
+      const envelope = JSON.parse(raw);
+      log({
+        tool: "local-controller-envelope",
+        fields: Object.keys(envelope).sort(),
+        templateDigest: envelope.templateDigest,
+        image: envelope.image,
+      });
+      process.stdout.write(JSON.stringify({
+        template: envelope.template,
+        deployment: envelope.deployment,
+        runId: "local-test-run",
+        url: envelope.publicUrl,
+      }) + "\\n");
+    });
+  }
+}
 `;
   const ssh = `#!/usr/bin/env node
 const fs = require("node:fs");
 const { createHash } = require("node:crypto");
 const args = process.argv.slice(2);
 const command = args.slice(5);
+const dockerIndex = command.indexOf("docker");
+const runtimeCommand = dockerIndex === -1 ? command : command.slice(dockerIndex);
 const log = value => fs.appendFileSync(process.env.BIMO_TEST_LOG, JSON.stringify(value) + "\\n");
 log({ tool: "ssh", args, command });
-if (command[0] === "docker" && command[1] === "load") {
+if (runtimeCommand[0] === "docker" && runtimeCommand[1] === "version") {
+  process.stdout.write(process.env.BIMO_TEST_REMOTE_PLATFORM + "\\n");
+} else if (runtimeCommand[0] === "docker" && runtimeCommand[1] === "load") {
   process.stdin.resume();
   process.stdin.on("end", () => process.stdout.write("Loaded image\\n"));
-} else if (command[0] === "docker" && command[1] === "image" && command[2] === "inspect") {
+} else if (runtimeCommand[0] === "docker" && runtimeCommand[1] === "image" && runtimeCommand[2] === "inspect") {
   process.stdout.write(process.env.BIMO_TEST_REMOTE_INSPECT + "\\n");
-} else if (command[0] === "docker" && command[1] === "run") {
+} else if (runtimeCommand[0] === "docker" && runtimeCommand[1] === "run"
+    && runtimeCommand.includes("internal-logs")) {
+  process.stdout.write("");
+} else if (runtimeCommand[0] === "docker" && runtimeCommand[1] === "run") {
   let raw = "";
   process.stdin.setEncoding("utf8");
   process.stdin.on("data", chunk => { raw += chunk; });
@@ -244,9 +285,16 @@ else process.stdout.write("sk-or-v1-${"k".repeat(32)}\\n");
     env: {
       ...process.env,
       PATH: `${directory}${path.delimiter}${process.env.PATH}`,
+      DOCKER_HOST: "",
       BIMO_TEST_LOG: logFile,
-      BIMO_TEST_LOCAL_INSPECT: imageInspect(LOCAL_IMAGE_ID),
-      BIMO_TEST_REMOTE_INSPECT: imageInspect(remoteImageId, { config: remoteConfig, layers: remoteLayers }),
+      BIMO_TEST_DOCKER_ENDPOINT: "unix:///tmp/bimo-test-docker.sock",
+      BIMO_TEST_LOCAL_INSPECT: imageInspect(LOCAL_IMAGE_ID, { architecture: localArchitecture }),
+      BIMO_TEST_REMOTE_INSPECT: imageInspect(remoteImageId, {
+        architecture: remotePlatform.split("/")[1],
+        config: remoteConfig,
+        layers: remoteLayers,
+      }),
+      BIMO_TEST_REMOTE_PLATFORM: remotePlatform,
       BIMO_TEST_CONTROLLER: controller,
       BIMO_TEST_POD_CANDIDATE: POD_CANDIDATE_SHA,
       BIMO_TEST_ORGANIZER_TEMPLATE: "react-app",
@@ -254,7 +302,7 @@ else process.stdout.write("sk-or-v1-${"k".repeat(32)}\\n");
         templateRoot: path.join(root, "templates"),
       })).templateDigest,
       BIMO_TEST_ORGANIZER_OPTIONS: JSON.stringify([
-        "--deployment", "--host", "--proxmox", "--vmid", "--task-file", "--task-stdin",
+        "--deployment", "--target", "--host", "--proxmox", "--vmid", "--task-file", "--task-stdin",
         "--secret-ref", "--public-url", "--port",
       ]),
     },
@@ -336,6 +384,146 @@ test("the installed CLI lists the packaged workflows and fixed engineering pod",
   )));
 });
 
+test("targets reports the working local Docker adapter and the two on-demand access adapters", async t => {
+  const tools = await fakeDeployTools(t);
+  const result = await invoke(["targets", "--json"], { env: tools.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    targets: [
+      {
+        kind: "local",
+        runtime: "docker",
+        configuration: "automatic",
+        availability: "ready",
+        platform: "linux/arm64",
+      },
+      {
+        kind: "ssh",
+        runtime: "docker",
+        configuration: "--host HOST",
+        availability: "on-demand",
+      },
+      {
+        kind: "proxmox-lxc",
+        runtime: "docker",
+        configuration: "--proxmox HOST --vmid ID",
+        availability: "on-demand",
+      },
+    ],
+  });
+  const commands = await readCommandLog(tools.logFile);
+  assert.deepEqual(commands, [
+    {
+      tool: "docker",
+      args: ["context", "inspect", "--format", "{{(index .Endpoints \"docker\").Host}}"],
+    },
+    {
+      tool: "docker",
+      args: ["version", "--format", "{{.Server.Os}}/{{.Server.Arch}}"],
+    },
+  ]);
+});
+
+test("targets fails closed for non-local Docker endpoints and DOCKER_HOST overrides", async t => {
+  const tools = await fakeDeployTools(t);
+  const remoteEndpoint = await invoke(["targets", "--json"], {
+    env: { ...tools.env, BIMO_TEST_DOCKER_ENDPOINT: "tcp://docker.example:2376" },
+  });
+  assert.equal(remoteEndpoint.code, 0, remoteEndpoint.stderr);
+  assert.deepEqual(JSON.parse(remoteEndpoint.stdout).targets[0], {
+    kind: "local",
+    runtime: "docker",
+    configuration: "automatic",
+    availability: "unavailable",
+    reason: "Docker endpoint is not a local Unix socket",
+  });
+
+  const overridden = await invoke(["targets", "--json"], {
+    env: { ...tools.env, DOCKER_HOST: "unix:///tmp/untrusted-docker.sock" },
+  });
+  assert.equal(overridden.code, 0, overridden.stderr);
+  assert.equal(JSON.parse(overridden.stdout).targets[0].reason,
+    "DOCKER_HOST overrides are not accepted for local targets");
+});
+
+test("deploy defaults to local Docker without SSH or image transfer", async t => {
+  const tools = await fakeDeployTools(t, {
+    controller: "workflow-success",
+    localArchitecture: "arm64",
+  });
+  const args = deployArgs(tools.taskFile).filter((value, index, all) => (
+    value !== "--host" && all[index - 1] !== "--host"
+  ));
+  const result = await invoke(args, { env: tools.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    template: "react-app",
+    deployment: "fleet-demo",
+    runId: "local-test-run",
+    url: "http://example.invalid:8080",
+  });
+
+  const entries = await readCommandLog(tools.logFile);
+  assert.equal(entries.some(entry => entry.tool === "ssh"), false);
+  const docker = entries.filter(entry => entry.tool === "docker").map(entry => entry.args);
+  assert.ok(docker.some(command => command[0] === "build"
+    && command.includes("--tag") && !command.includes("--platform")));
+  assert.equal(docker.some(command => command[0] === "save"), false);
+  assert.equal(docker.some(command => command[0] === "image" && command[1] === "tag"), false);
+
+  const hostRoot = path.join(os.homedir(), ".local", "share", "bimo", "deployments", "fleet-demo");
+  const prepare = docker.find(command => command.includes("internal-prepare"));
+  const controller = docker.find(command => command.includes("internal-run"));
+  assert.ok(prepare);
+  assert.ok(controller);
+  assert.ok(prepare.includes(`${hostRoot}:/deployment:rw`));
+  assert.ok(controller.includes(`${hostRoot}/runs:/state:rw`));
+  assert.ok(controller.includes(`${hostRoot}/workspace:/workspace:rw`));
+  assert.equal(controller[controller.indexOf("--local-home") + 1], os.homedir());
+  assert.equal(controller[controller.indexOf("internal-run") - 1], LOCAL_IMAGE_ID);
+  const envelope = entries.find(entry => entry.tool === "local-controller-envelope");
+  assert.equal(envelope.image, LOCAL_IMAGE_ID);
+});
+
+test("explicit SSH target builds for the target daemon architecture", async t => {
+  const tools = await fakeDeployTools(t, {
+    controller: "workflow-success",
+    remotePlatform: "linux/arm64",
+    localArchitecture: "arm64",
+  });
+  const args = deployArgs(tools.taskFile);
+  args.splice(args.indexOf("--host"), 0, "--target", "ssh");
+  const result = await invoke(args, { env: tools.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  const entries = await readCommandLog(tools.logFile);
+  const build = entries.find(entry => entry.tool === "docker" && entry.args[0] === "build");
+  assert.ok(build);
+  assert.equal(build.args[build.args.indexOf("--platform") + 1], "linux/arm64");
+  assert.ok(entries.some(entry => entry.tool === "ssh"
+    && entry.command.join(" ").includes("docker version --format")));
+});
+
+test("explicit Proxmox LXC target wraps Docker with pct exec", async t => {
+  const tools = await fakeDeployTools(t);
+  const result = await invoke([
+    "logs",
+    "--deployment", "fleet-demo",
+    "--target", "proxmox-lxc",
+    "--proxmox", "root@pve-05",
+    "--vmid", "212",
+    "--image", "bimo-workflow:test",
+  ], { env: tools.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  const entries = await readCommandLog(tools.logFile);
+  const invocation = entries.find(entry => entry.tool === "ssh");
+  assert.deepEqual(invocation.command.slice(0, 5), ["pct", "exec", "212", "--", "docker"]);
+  assert.ok(invocation.command.includes("internal-logs"));
+});
+
 test("the installed CLI validates the packaged React workflow", async () => {
   const result = await run("validate", "react-app", "--json");
   assert.equal(result.valid, true);
@@ -368,6 +556,7 @@ test("the package ships its runnable how-to and example prompts", async () => {
   for (const expected of [
     "README.md",
     "docs/organize.md",
+    "docs/targets.md",
     "examples/fleet-demo.md",
     "examples/solo-demo.md",
     "examples/prompts/small-app.md",
@@ -405,7 +594,7 @@ test("organize transfers content-verified image without retagging and runs one e
     template: "react-app",
     templateDigest: response.templateDigest,
     acceptedOptions: [
-      "--deployment", "--host", "--proxmox", "--vmid", "--task-file", "--task-stdin",
+      "--deployment", "--target", "--host", "--proxmox", "--vmid", "--task-file", "--task-stdin",
       "--secret-ref", "--public-url", "--port",
     ],
   });

--- a/test/deployment-target.test.mjs
+++ b/test/deployment-target.test.mjs
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, symlink } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  commandForTarget,
+  deploymentRootForTarget,
+  isDeploymentHostRoot,
+  resolveDeploymentTarget,
+} from "../src/deployment-target.mjs";
+
+test("local is the default deployment target with a user-owned state root", () => {
+  const home = os.homedir();
+  const target = resolveDeploymentTarget({}, { home });
+
+  assert.deepEqual(target, {
+    kind: "local",
+    runtime: "docker",
+    home,
+  });
+  assert.equal(
+    deploymentRootForTarget(target, "fleet-demo"),
+    path.join(home, ".local", "share", "bimo", "deployments", "fleet-demo"),
+  );
+  assert.deepEqual(commandForTarget(target, ["docker", "info"]), {
+    command: "docker",
+    args: ["info"],
+  });
+});
+
+test("local target rejects a symlinked home before constructing bind mounts", async t => {
+  const parent = await mkdtemp(path.join(os.tmpdir(), "bimo-target-home-"));
+  const realHome = path.join(parent, "real");
+  const linkedHome = path.join(parent, "linked");
+  await mkdir(realHome);
+  await symlink(realHome, linkedHome);
+  t.after(() => rm(parent, { recursive: true, force: true }));
+
+  assert.throws(
+    () => resolveDeploymentTarget({}, { home: linkedHome }),
+    /local home directory must not be a symlink/,
+  );
+});
+
+test("legacy and explicit SSH targets resolve to the same closed built-in adapter", () => {
+  const legacy = resolveDeploymentTarget({ host: "builder.example" });
+  const explicit = resolveDeploymentTarget({ target: "ssh", host: "builder.example" });
+
+  assert.deepEqual(explicit, legacy);
+  assert.deepEqual(commandForTarget(explicit, ["docker", "info"]), {
+    command: "ssh",
+    args: [
+      "-o", "BatchMode=yes",
+      "-o", "StrictHostKeyChecking=yes",
+      "builder.example",
+      "docker", "info",
+    ],
+  });
+  assert.equal(
+    deploymentRootForTarget(explicit, "fleet-demo"),
+    "/var/lib/bimo/deployments/fleet-demo",
+  );
+});
+
+test("legacy and explicit Proxmox LXC targets retain the pct execution boundary", () => {
+  const legacy = resolveDeploymentTarget({ proxmox: "root@pve-05", vmid: "212" });
+  const explicit = resolveDeploymentTarget({
+    target: "proxmox-lxc",
+    proxmox: "root@pve-05",
+    vmid: "212",
+  });
+
+  assert.deepEqual(explicit, legacy);
+  assert.deepEqual(commandForTarget(explicit, ["docker", "info"]), {
+    command: "ssh",
+    args: [
+      "-o", "BatchMode=yes",
+      "-o", "StrictHostKeyChecking=yes",
+      "root@pve-05",
+      "pct", "exec", "212", "--",
+      "docker", "info",
+    ],
+  });
+});
+
+test("target selection rejects ambiguous or incomplete adapter configuration", () => {
+  for (const [options, pattern] of [
+    [{ target: "other" }, /--target must be local, ssh, or proxmox-lxc/],
+    [{ target: "local", host: "builder.example" }, /--host is not valid with --target local/],
+    [{ target: "ssh" }, /--host is required with --target ssh/],
+    [{ target: "ssh", host: "builder.example", vmid: "212" }, /--vmid is only valid/],
+    [{ target: "proxmox-lxc", proxmox: "pve-05" }, /--vmid must be numeric/],
+    [{ host: "builder.example", proxmox: "pve-05", vmid: "212" }, /use only one target/],
+  ]) {
+    assert.throws(() => resolveDeploymentTarget(options), pattern);
+  }
+});
+
+test("controller host roots accept only canonical remote or local deployment roots", () => {
+  assert.equal(isDeploymentHostRoot("/var/lib/bimo/deployments/demo", "demo"), true);
+  assert.equal(
+    isDeploymentHostRoot("/Users/tester/.local/share/bimo/deployments/demo", "demo", {
+      localHome: "/Users/tester",
+    }),
+    true,
+  );
+  assert.equal(
+    isDeploymentHostRoot("/tmp/x/.local/share/bimo/deployments/demo", "demo", {
+      localHome: "/Users/tester",
+    }),
+    false,
+  );
+  assert.equal(isDeploymentHostRoot("/var/lib/bimo/deployments/other", "demo"), false);
+  assert.equal(
+    isDeploymentHostRoot("/Users/tester/.local/share/bimo/deployments/other", "demo", {
+      localHome: "/Users/tester",
+    }),
+    false,
+  );
+  assert.equal(
+    isDeploymentHostRoot("/Users/tester/../tester/.local/share/bimo/deployments/demo", "demo", {
+      localHome: "/Users/tester",
+    }),
+    false,
+  );
+});

--- a/test/docker-runtime.test.mjs
+++ b/test/docker-runtime.test.mjs
@@ -88,6 +88,10 @@ function createRuntime(overrides = {}) {
 }
 
 test("runtime host root is bound to its deployment name", () => {
+  assert.doesNotThrow(() => createRuntime({
+    hostRoot: "/Users/tester/.local/share/bimo/deployments/demo",
+    localHome: "/Users/tester",
+  }));
   assert.throws(
     () => createRuntime({ hostRoot: "/var/lib/bimo/deployments/another" }),
     /host root must match deployment/,
@@ -465,6 +469,7 @@ test("source verification containers receive only immutable snapshots and no con
   const receipt = { files: 12, bytes: 4_096, sha256: "c".repeat(64) };
   const candidate = sourceVerifierCreateArgs({
     deployment: "demo",
+    hostRoot: "/var/lib/bimo/deployments/demo",
     image: IMAGE,
     snapshotHost: "/var/lib/bimo/deployments/demo/snapshots/run-1/candidate-1",
     expectedSha: "d".repeat(40),
@@ -476,6 +481,7 @@ test("source verification containers receive only immutable snapshots and no con
   });
   const baseline = sourceVerifierCreateArgs({
     deployment: "demo",
+    hostRoot: "/var/lib/bimo/deployments/demo",
     image: IMAGE,
     snapshotHost: "/var/lib/bimo/deployments/demo/snapshots/run-1/candidate-1",
     baselineTestHost: "/var/lib/bimo/deployments/demo/snapshots/run-1/base/test",
@@ -499,6 +505,34 @@ test("source verification containers receive only immutable snapshots and no con
     assert.match(rendered, /--tmpfs \/test-tools:rw,exec,nosuid,nodev,size=32m,uid=1000,gid=1000/);
     assert.doesNotMatch(rendered, /docker\.sock|dst=\/state|BIMO_GATEWAY|sk-or-v1|github_pat_/);
   }
+
+  const local = sourceVerifierCreateArgs({
+    deployment: "demo",
+    hostRoot: "/Users/tester/.local/share/bimo/deployments/demo",
+    localHome: "/Users/tester",
+    image: IMAGE,
+    snapshotHost: "/Users/tester/.local/share/bimo/deployments/demo/snapshots/run-1/candidate-1",
+    expectedSha: "d".repeat(40),
+    expectedSnapshot: receipt,
+    profile: "bimo-repo-v1",
+    suite: "candidate",
+    timeoutSeconds: 300,
+    nameSuffix: "source-candidate",
+  });
+  assert.match(local.join(" "), /src=\/Users\/tester\/\.local\/share\/bimo\/deployments\/demo\/snapshots/);
+  assert.throws(() => sourceVerifierCreateArgs({
+    deployment: "demo",
+    hostRoot: "/Users/tester/.local/share/bimo/deployments/demo",
+    localHome: "/Users/other",
+    image: IMAGE,
+    snapshotHost: "/Users/tester/.local/share/bimo/deployments/demo/snapshots/run-1/candidate-1",
+    expectedSha: "d".repeat(40),
+    expectedSnapshot: receipt,
+    profile: "bimo-repo-v1",
+    suite: "candidate",
+    timeoutSeconds: 300,
+    nameSuffix: "source-candidate",
+  }), /invalid source verifier host root/);
 });
 
 test("verifySource binds candidate and immutable-base evidence without mounting controller state", async () => {


### PR DESCRIPTION
## Summary

Operators can now run the same bounded Bimo workflow directly on a Mac or Linux Docker daemon, or route it through Docker-over-SSH and Proxmox LXC, without adding a cloud control plane. Local Docker is the v0.5 default; the existing `--host` and `--proxmox ... --vmid ...` commands remain compatible.

The target seam is deliberately closed. Templates remain data-only, while the operator CLI alone chooses placement, validates target state, resolves secrets, prepares an architecture-matched image, and owns cleanup.

## Design decisions

| Decision | Result |
| --- | --- |
| Keep three built-in adapters | `local`, `ssh`, and `proxmox-lxc` share one explicit Docker runtime instead of introducing an executable plugin ABI before a second runtime exists. |
| Make local state user-owned | Local runs live under `~/.local/share/bimo/deployments/<name>`; remote state remains under `/var/lib/bimo/deployments/<name>`. |
| Probe architecture before build | Local and remote daemons must report `linux/amd64` or `linux/arm64`; Bimo builds and verifies the matching image. |
| Fail closed on ambient routing | Local mode requires the active Unix-socket Docker context and rejects `DOCKER_HOST` overrides, symlinked homes, and redirected state paths. |

## Operator surface

```bash
bimo targets
bimo deploy react-solo --deployment demo --task-file assignment.md \
  --secret-ref 'op://VAULT/ITEM/FIELD' \
  --public-url http://127.0.0.1:8080

bimo deploy react-app --deployment remote-demo \
  --target ssh --host deploy@docker-host \
  --task-file assignment.md --secret-ref 'op://VAULT/ITEM/FIELD' \
  --public-url http://docker-host:8080
```

Apple `container`, Seatbelt, native LXC lifecycle management, and Proxmox API provisioning remain explicit non-capabilities. They should enter through the same bounded target contract only after each has a real deploy and log path.

## Runtime proof

This is product output from the retained local v0.5 deployment, not test output:

```text
$ bimo targets --json
{"targets":[{"kind":"local","runtime":"docker","configuration":"automatic","availability":"ready","platform":"linux/arm64"},{"kind":"ssh","runtime":"docker","configuration":"--host HOST","availability":"on-demand"},{"kind":"proxmox-lxc","runtime":"docker","configuration":"--proxmox HOST --vmid ID","availability":"on-demand"}]}

$ bimo logs --deployment local-v050-proof --run 20260826164349-5bf2ef18 --json | jq summary
{
  "events": 6,
  "finished": {
    "type": "run.finished",
    "status": "completed",
    "runId": "20260826164349-5bf2ef18"
  }
}

$ curl http://127.0.0.1:18087/ | rg marker
BIMO_DEMO_READY
```

## Verification

- `npm test` — 215/215 passing in a clean, sequential run.
- `npm pack --json --dry-run` — v0.5.0 package contains 55 intended files.
- `docker build --tag bimo-workflow:0.5.0 .` — built `linux/arm64` image `sha256:286f435a1cf8c0e4591c38d230c2dd948b597eed00ac24a03082792143a51b55`.
- Real `react-solo` agent run — deterministic test, build, smoke, artifact snapshot, HTTP verification, and publication all passed.
- Five independent follow-up validators confirmed the source-root, home-path, Docker endpoint, architecture, and controller-boundary fixes.

## Post-deploy monitoring

- Expected signals: `bimo targets` reports the local adapter `ready`; run logs end with `run.finished` / `completed`; the published artifact returns the required marker.
- Failure signals: local target `unavailable`, a nonzero controller exit, missing `run.finished`, or a missing HTTP marker.
- Validation window: verify the release artifact immediately after installation and watch the first local and remote runs through completion.
- Rollback: reinstall v0.4.0, or revert this commit and redeploy under a fresh deployment name; existing deployment state is not migrated or deleted.
- Owner: the Bimo operator running the deployment.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
