### PR TITLE
Fix --deployment presence error; add --version, -h alias, and exit 1 for bare bimo

### DIFF
--- a/src/bimo.mjs
+++ b/src/bimo.mjs
@@ -784,7 +784,8 @@ async function deploy(template, options) {
     "deployment", "target", "proxmox", "host", "vmid", "task-file", "task-stdin",
     "secret-ref", "account", "public-url", "port", "model", "image", "json",
   ]);
-  if (!NAME.test(options.deployment ?? "")) fail("--deployment must use lowercase letters, numbers, and dashes");
+  if (!options.deployment) fail("--deployment is required");
+  if (!NAME.test(options.deployment)) fail("--deployment must use lowercase letters, numbers, and dashes");
   const deploymentTarget = resolveDeploymentTarget(options);
   const image = options.image ?? DEFAULT_IMAGE;
   if (!IMAGE.test(image)) fail("--image is invalid");
@@ -957,7 +958,8 @@ async function organizeRemote(options) {
     "prompt", "agents", "deployment", "target", "proxmox", "host", "vmid",
     "secret-ref", "account", "model", "image", "json",
   ]);
-  if (!NAME.test(options.deployment ?? "")) {
+  if (!options.deployment) fail("--deployment is required");
+  if (!NAME.test(options.deployment)) {
     fail("--deployment must use lowercase letters, numbers, and dashes");
   }
   const deploymentTarget = resolveDeploymentTarget(options);
@@ -1461,8 +1463,18 @@ export async function main(argv = process.argv.slice(2)) {
     command = "organize";
     rest = argv;
   }
-  if (!command || command === "help" || command === "--help") {
+  if (!command) {
     process.stdout.write(usage());
+    process.exitCode = 1;
+    return;
+  }
+  if (command === "help" || command === "--help" || command === "-h") {
+    process.stdout.write(usage());
+    return;
+  }
+  if (command === "--version") {
+    const manifest = JSON.parse(await readFile(path.join(packageRoot, "package.json"), "utf8"));
+    process.stdout.write(`${manifest.version}\n`);
     return;
   }
   if (command === "list") {

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -384,6 +384,48 @@ test("the installed CLI lists the packaged workflows and fixed engineering pod",
   )));
 });
 
+test("bare bimo prints usage and exits 1, while the help aliases print usage and exit 0", async () => {
+  const bare = await invoke([]);
+  assert.equal(bare.code, 1);
+  assert.match(bare.stdout, /^usage:/);
+  assert.equal(bare.stderr, "");
+
+  for (const flag of ["--help", "-h"]) {
+    const result = await invoke([flag]);
+    assert.equal(result.code, 0, result.stderr);
+    assert.equal(result.stdout, bare.stdout);
+    assert.equal(result.stderr, "");
+  }
+});
+
+test("--version prints the packaged version and exits 0", async () => {
+  const manifest = JSON.parse(await readFile(path.join(root, "package.json"), "utf8"));
+  const result = await invoke(["--version"]);
+  assert.equal(result.code, 0, result.stderr);
+  assert.equal(result.stdout, `${manifest.version}\n`);
+  assert.equal(result.stderr, "");
+});
+
+test("organize and deploy require --deployment before validating its format", async () => {
+  const organizeBase = [
+    "organize", "--prompt", "Build a small status page.",
+    "--host", "example.invalid",
+    "--secret-ref", "op://Test/Bimo/openrouter",
+  ];
+  for (const [args, pattern] of [
+    [organizeBase, /--deployment is required/],
+    [[...organizeBase, "--deployment", "Organizer_Demo"],
+      /--deployment must use lowercase letters, numbers, and dashes/],
+    [["deploy", "react-app"], /--deployment is required/],
+    [["deploy", "react-app", "--deployment", "Fleet_Demo"],
+      /--deployment must use lowercase letters, numbers, and dashes/],
+  ]) {
+    const result = await invoke(args);
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, pattern);
+  }
+});
+
 test("targets reports the working local Docker adapter and the two on-demand access adapters", async t => {
   const tools = await fakeDeployTools(t);
   const result = await invoke(["targets", "--json"], { env: tools.env });


### PR DESCRIPTION
Closes #8
Closes #9

## Changes

- `src/bimo.mjs` (`deploy`, `organizeRemote`): check `--deployment` presence before format — a missing flag now fails with `--deployment is required` (matching `--secret-ref is required`), while present-but-malformed values keep the existing format message.
- `main()` dispatch:
  - `--version` prints the version from the packaged `package.json` (read via the existing `packageRoot`) and exits 0.
  - `-h` is an exact alias of `--help` (usage, exit 0).
  - Bare `bimo` with no arguments still prints usage but now exits 1; explicit `--help`/`-h`/`help` keep exit 0.
- `test/cli.test.mjs`: new tests covering missing vs malformed `--deployment` for both `organize` and `deploy`, `--version` output, `-h`/`--help` exit 0, and bare `bimo` exit 1.

`npm test`: 218/218 passing; `node --check src/bimo.mjs` clean.