### PR TITLE
Fix pod context: Testing verification claim, Checker criteria, retry directives

### DIFF
--- a/src/pod-controller.mjs
+++ b/src/pod-controller.mjs
@@ -310,6 +310,10 @@ export async function runEngineeringPod({
       prompt: buildPrompt(prompts.checker, "checker", {
         assignment,
         requirementIds: workItem.requirementIds,
+        requirements: attemptState.plan.requirements
+          .filter(item => workItem.requirementIds.includes(item.id)),
+        acceptanceCriteria: attemptState.plan.acceptanceCriteria
+          .filter(item => workItem.acceptanceIds.includes(item.id)),
         workItem,
         baseSha: result.baseSha,
         resultSha: result.resultSha,
@@ -347,22 +351,44 @@ export async function runEngineeringPod({
     return receipt;
   };
 
-  const executeWriter = ({ attemptState, workItem, workspace, inbox, execution, executionBaseSha }) => runAgent({
-    executionId: execution,
-    role: workItem.ownerSlot,
-    attempt: attemptState.attempt,
-    access: "write",
-    prompt: buildPrompt(prompts[workItem.ownerSlot], "writer", {
-      assignment,
-      plan: attemptState.plan,
-      workItem,
-      inbox,
-      executionBaseSha,
-    }),
-    workspaceId: workspace.id,
-    writeDirectories: workspace.writeDirectories,
-    deadlineAt: attemptState.deadlineAt,
-  });
+  const retryContext = workItem => {
+    const prior = priorAttempts.at(-1);
+    if (!prior) return null;
+    const failedGate = [...prior.gates].reverse().find(gate => gate.outcome !== "passed") ?? null;
+    const gate = failedGate?.gate ?? "attempt";
+    const correction = failedGate?.workItemId === workItem.id
+      ? `Attempt ${prior.attempt} failed the ${gate} gate on your writer item. Correct only your assigned work within its writePaths so this exact gate passes on the replacement attempt.`
+      : `Attempt ${prior.attempt} failed the ${gate} gate. Correct only your assigned work within its writePaths so this exact gate passes on the replacement attempt.`;
+    return {
+      attempt: prior.attempt,
+      gate,
+      outcome: failedGate?.outcome ?? "failed",
+      reason: prior.reason,
+      evidence: failedGate?.evidence ?? [],
+      correction,
+    };
+  };
+
+  const executeWriter = ({ attemptState, workItem, workspace, inbox, execution, executionBaseSha }) => {
+    const retry = retryContext(workItem);
+    return runAgent({
+      executionId: execution,
+      role: workItem.ownerSlot,
+      attempt: attemptState.attempt,
+      access: "write",
+      prompt: buildPrompt(prompts[workItem.ownerSlot], "writer", {
+        assignment,
+        plan: attemptState.plan,
+        workItem,
+        inbox,
+        executionBaseSha,
+        ...(retry ? { retry } : {}),
+      }),
+      workspaceId: workspace.id,
+      writeDirectories: workspace.writeDirectories,
+      deadlineAt: attemptState.deadlineAt,
+    });
+  };
 
   const validateWriter = (raw, {
     attemptState,

--- a/templates/parallel-engineering-pod/roles/checker.md
+++ b/templates/parallel-engineering-pod/roles/checker.md
@@ -1,8 +1,9 @@
 # Checker
 
 Review one exact writer result read-only. The controller supplies the original
-assignment, immutable attempt plan, item brief, exact base and result SHAs,
-canonical diff, and the exact delivered inbox slice. You cannot repair code.
+assignment, the full text of the item's assigned requirements and acceptance
+criteria, the item brief, exact base and result SHAs, canonical diff, and the
+exact delivered inbox slice. You cannot repair code.
 
 Your workspace intentionally contains the immutable base plus only this one
 writer result. Concurrent writer results are not present yet. Do not fail this

--- a/templates/parallel-engineering-pod/roles/engineering.md
+++ b/templates/parallel-engineering-pod/roles/engineering.md
@@ -11,8 +11,10 @@ path already covered by the owner's brief and `writePaths`. Any other dependency
 is structural and ends the attempt.
 
 When resumed, treat only the controller-delivered inbox slice as new context.
-Report its cursor exactly. Write one JSON object with exactly these fields to
-`/handoff/result.json`:
+Report its cursor exactly. On a replacement attempt the controller adds a
+`retry` context naming the failed gate, its exact evidence, and a targeted
+correction request; address it within your assigned `writePaths` only. Write
+one JSON object with exactly these fields to `/handoff/result.json`:
 
 ```json
 {

--- a/templates/parallel-engineering-pod/roles/qa-tests.md
+++ b/templates/parallel-engineering-pod/roles/qa-tests.md
@@ -5,8 +5,10 @@ write only beneath the static `writePaths` assigned to `qa-tests`. Do not edit
 product code, Git metadata, workflow files, credentials, or another worktree.
 
 Tests must express the acceptance criteria without weakening them after seeing
-the implementation. Write one JSON object with exactly these fields to
-`/handoff/result.json`:
+the implementation. On a replacement attempt the controller adds a `retry`
+context naming the failed gate, its exact evidence, and a targeted correction
+request; address it within your assigned `writePaths` only. Write one JSON
+object with exactly these fields to `/handoff/result.json`:
 
 ```json
 {

--- a/templates/parallel-engineering-pod/roles/testing.md
+++ b/templates/parallel-engineering-pod/roles/testing.md
@@ -1,14 +1,17 @@
 # Testing
 
-Act as the final read-only semantic gate for the exact candidate SHA. Inspect
-the trusted controller results for verification profile `bimo-repo-v1` and
-reproduce read-only observations when requested. Never modify the candidate,
-install dependencies, or repair a failure.
+Act as the final read-only semantic gate for the exact candidate SHA. Trusted
+verification has not run yet: the controller runs its allowlisted verifier for
+verification profile `bimo-repo-v1` only after your verdict, so never claim
+that trusted verification passed and never cite verifier results as evidence.
+Rely on your own read-only observations of the exact candidate. Never modify
+the candidate, install dependencies, or repair a failure.
 
 Return `passed` only when every required check succeeds against the exact
 candidate SHA with sufficient evidence. Otherwise return `failed`. Your verdict
-is semantic and advisory; the controller's allowlisted verifier is authoritative
-and publication may create only a draft pull request.
+is semantic and advisory; the controller's allowlisted verifier is
+authoritative, runs only after this gate, and publication may create only a
+draft pull request.
 
 Write one JSON object with exactly these fields to `/handoff/result.json`:
 
@@ -19,7 +22,7 @@ Write one JSON object with exactly these fields to `/handoff/result.json`:
   "candidateSha": "<exact candidate SHA>",
   "what": "What was tested.",
   "why": "Why the candidate passes or must retry.",
-  "evidence": ["Exact trusted verifier result."],
+  "evidence": ["Exact read-only observation and result."],
   "requirementIds": ["REQ-ONE"],
   "acceptanceIds": ["AC-ONE"]
 }

--- a/test/pod-contract.test.mjs
+++ b/test/pod-contract.test.mjs
@@ -245,6 +245,17 @@ test("packaged prompts state the strict handoff fields and deterministic authori
   assert.doesNotMatch(loaded.prompts.testing, /"files"\s*:/);
 });
 
+test("the packaged Testing prompt never claims trusted verification already ran", async () => {
+  const loaded = await loadPodTemplate("parallel-engineering-pod", {
+    templateRoot: path.join(root, "templates"),
+  });
+
+  assert.match(loaded.prompts.testing, /has not run/i);
+  assert.match(loaded.prompts.testing, /only after/i);
+  assert.doesNotMatch(loaded.prompts.testing, /trusted (controller|verifier) results/i);
+  assert.doesNotMatch(loaded.prompts.testing, /Exact trusted verifier result/i);
+});
+
 test("an attempt is one complete fixed plan from the immutable run base", () => {
   const plan = attemptPlan();
   assert.equal(validateAttemptPlan(plan, {

--- a/test/pod-controller.test.mjs
+++ b/test/pod-controller.test.mjs
@@ -343,6 +343,14 @@ test("fans out all three writers, checks exact results, and marks the tested can
       if (input.role === "checker") {
         const writerId = ["engineering-a", "engineering-b", "qa-tests"]
           .find(slot => input.executionId.endsWith(slot));
+        const prompt = promptContext(input.prompt);
+        const writer = attemptPlan.writers[writerId];
+        assert.deepEqual(prompt.requirements, attemptPlan.requirements
+          .filter(item => writer.requirementIds.includes(item.id)));
+        assert.deepEqual(prompt.acceptanceCriteria, attemptPlan.acceptanceCriteria
+          .filter(item => writer.acceptanceIds.includes(item.id)));
+        assert(prompt.requirements.every(item => typeof item.text === "string" && item.text.length > 0));
+        assert(prompt.acceptanceCriteria.every(item => typeof item.text === "string" && item.text.length > 0));
         const commit = calls.find(call => call.type === "commit" && call.input.workItem.id === writerId).input;
         const resultSha = {
           "engineering-a": SHA.engineeringA,
@@ -882,6 +890,108 @@ test("a red Testing gate starts a complete next attempt from the immutable run b
   assert.equal(writerExecutions.length, 6);
   assert.equal(verificationCalls, 1);
   assert.deepEqual(calls.filter(call => call.type === "integrate").map(call => call.input.attempt), [1, 2]);
+});
+
+test("retry writers receive the failed gate, its exact evidence, and a targeted correction", async () => {
+  const calls = [];
+  const store = createStore();
+  const source = createSource(calls);
+  const writerPrompts = [];
+
+  const agents = {
+    async cancel() {
+      calls.push({ type: "cancel" });
+    },
+    async runAgentExecution(input) {
+      calls.push({ type: "agent", input });
+      const attemptPlan = plan(input.attempt);
+      if (input.role === "planner") return { receipt: attemptPlan };
+      if (["engineering-a", "engineering-b", "qa-tests"].includes(input.role)) {
+        writerPrompts.push({ executionId: input.executionId, context: promptContext(input.prompt) });
+        return { receipt: writerReceipt(input.role, attemptPlan) };
+      }
+      if (input.role === "checker") {
+        const prompt = promptContext(input.prompt);
+        const writer = prompt.workItem;
+        return {
+          receipt: {
+            outcome: "passed",
+            baseSha: prompt.baseSha,
+            resultSha: prompt.resultSha,
+            diffSha256: prompt.diffSha256,
+            what: `Checked ${writer.ownerSlot}.`,
+            why: "The exact result passes.",
+            evidence: [`checker:${writer.ownerSlot}:passed`],
+            requirementIds: [...writer.requirementIds],
+            acceptanceIds: [...writer.acceptanceIds],
+            files: [],
+            deliveredInbox: [],
+          },
+        };
+      }
+      if (input.role === "qa") {
+        return {
+          receipt: {
+            gate: "qa",
+            outcome: "passed",
+            candidateSha: SHA.candidate,
+            what: "The exact integrated candidate conforms.",
+            why: "The product and tests conform.",
+            evidence: ["qa:passed"],
+            requirementIds: attemptPlan.requirements.map(item => item.id),
+            acceptanceIds: attemptPlan.acceptanceCriteria.map(item => item.id),
+            files: [],
+          },
+        };
+      }
+      if (input.role === "testing") {
+        const failed = input.attempt === 1;
+        return {
+          receipt: {
+            gate: "testing",
+            outcome: failed ? "failed" : "passed",
+            candidateSha: SHA.candidate,
+            what: failed ? "The exact candidate has a regression." : "The exact candidate is ready.",
+            why: failed ? "The regression gate is red." : "The testing review found no red condition.",
+            evidence: [failed ? "testing:failed:REGRESSION-9" : "testing:passed"],
+            requirementIds: attemptPlan.requirements.map(item => item.id),
+            acceptanceIds: attemptPlan.acceptanceCriteria.map(item => item.id),
+            files: [],
+          },
+        };
+      }
+      throw new Error(`unexpected role: ${input.role}`);
+    },
+  };
+
+  const result = await runEngineeringPod(controllerInput({
+    agents,
+    source,
+    store,
+    verifyCandidate: async input => ({
+      status: "passed",
+      candidateSha: input.expectedSha,
+      evidence: ["tests:passed"],
+    }),
+  }));
+
+  assert.equal(result.status, "ready");
+  const firstAttempt = writerPrompts.filter(entry => entry.executionId.startsWith("attempt-1-"));
+  const secondAttempt = writerPrompts.filter(entry => entry.executionId.startsWith("attempt-2-"));
+  assert.equal(firstAttempt.length, 3);
+  assert.equal(secondAttempt.length, 3);
+  assert(firstAttempt.every(entry => !Object.hasOwn(entry.context, "retry")));
+  for (const entry of secondAttempt) {
+    const retry = entry.context.retry;
+    assert(retry, `${entry.executionId} must receive the retry context`);
+    assert.equal(retry.attempt, 1);
+    assert.equal(retry.gate, "testing");
+    assert.equal(retry.outcome, "failed");
+    assert.deepEqual(retry.evidence, ["testing:failed:REGRESSION-9"]);
+    assert.match(retry.reason, /Testing review failed/);
+    assert.match(retry.correction, /testing/);
+    assert.match(retry.correction, /writePaths/);
+  }
 });
 
 test("a structural writer failure settles sibling executions before the replacement attempt", async () => {


### PR DESCRIPTION
Refs #7

Closes three alpha-blocker context bugs in the parallel-engineering-pod.

## Root causes and fixes

1. **Testing was told trusted verification already passed, but verification runs later.** The Testing role prompt (`templates/parallel-engineering-pod/roles/testing.md`) instructed the agent to "inspect the trusted controller results for verification profile `bimo-repo-v1`" and to cite the "exact trusted verifier result" as evidence — while `src/pod-controller.mjs` runs `verifyCandidate` strictly *after* the Testing gate (QA → Testing → trusted verification). Testing could only hallucinate those results. The prompt now states trusted verification has not run yet, runs only after Testing's verdict, and that Testing must rely on its own read-only observations and never cite verifier results as evidence.

2. **Checker received only requirement/acceptance IDs and a brief.** `checkWriterResult` in `src/pod-controller.mjs` passed `requirementIds` and the work item brief, never the criteria text, so Checker could not actually judge conformance. The checker context now includes the full `requirements` and `acceptanceCriteria` records (id + text) filtered to the work item's assigned IDs — derived from the already-validated attempt plan and bounded by the existing 252 KiB prompt cap in `buildPrompt`, the same bound that already covers the full plan handed to writers.

3. **Retry agents got generic "try again" context.** On a replacement attempt, writers received only assignment/plan/workItem; the failed gate evidence collected in `priorAttempts` went only to the planner. Writer prompts on attempts after a failure now include a bounded `retry` context: which gate failed (or `attempt` for structural failures), its outcome, the exact evidence the gate produced, the recorded failure reason, and a targeted correction request (scoped to the writer item when a checker gate rejected that item specifically).

`engineering.md` / `qa-tests.md` document the new `retry` context; `checker.md` documents the full criteria text. Receipts, digests, and caps are unchanged; template prompts stay data-only (the digest-bound loader re-hashes them at load).

## Tests

- New: retry writers receive the failed gate, its exact evidence, and a targeted correction (attempt-2 writer prompts carry `retry`; attempt-1 prompts do not).
- New: packaged Testing prompt never claims trusted verification already ran.
- Extended happy-path test: checker context carries the full assigned requirement/acceptance text records.

`npm test`: 220/220 green.