### PR TITLE
Add run discovery, log following, doctor preflight, and command help

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,27 @@ configured per command; their `on-demand` status means Bimo has not contacted a
 specific host yet. Local mode uses the active Unix-socket Docker context and
 rejects ambient `DOCKER_HOST` overrides.
 
+### Inspect runs and diagnose
+
+`runs`, `status`, and `logs` read the deployment's durable state root through a
+read-only, network-disabled container on the target. `doctor` runs locally and
+checks Docker, target reachability, state-root writability, disk headroom, and
+credential resolvability, reporting pass, fail, or skip per check and exiting
+non-zero on any failure. Every command accepts the same target flags as deploy.
+
+```bash
+bimo runs --deployment fleet-demo --proxmox root@pve-05 --vmid 113
+bimo status --deployment fleet-demo --host deploy@docker-host.example --json
+bimo logs --deployment fleet-demo --follow
+bimo doctor --deployment fleet-demo --host deploy@docker-host.example \
+  --secret-ref 'op://VAULT/ITEM/FIELD'
+bimo help doctor
+```
+
+`logs --follow` replays the run's events from the start and then polls for new
+ones until interrupted. `bimo help COMMAND` (or `bimo COMMAND --help`) prints a
+command-specific synopsis; bare `bimo help` keeps the full usage.
+
 ### Deploy locally
 
 With Docker available, no target flags are required. On this Mac, for example,

--- a/src/bimo.mjs
+++ b/src/bimo.mjs
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import { constants as fsConstants } from "node:fs";
 import {
+  access,
   lstat,
   mkdir,
   open,
@@ -16,6 +17,7 @@ import {
   builtInTargetCatalog,
   commandForTarget,
   deploymentRootForTarget,
+  deploymentsRootForTarget,
   isDeploymentHostRoot,
   resolveDeploymentTarget,
 } from "./deployment-target.mjs";
@@ -68,6 +70,12 @@ const DEPLOYMENT_LAYOUTS = {
   organizer: ["runs", "worktrees"],
   pod: ["runs", "source", "worktrees", "snapshots"],
 };
+const RUN_LIST_LIMIT = 50;
+const RUN_SCAN_LIMIT = 1_000;
+const FOLLOW_POLL_MS = 2_000;
+const TAIL_CHUNK_BYTES = 64 * 1024 + 1;
+const DOCTOR_MIN_FREE_BLOCKS = 1_048_576;
+const RUN_STATES = new Set(["running", "completed", "failed", "cancelled"]);
 
 function fail(message) {
   throw new Error(message);
@@ -129,6 +137,7 @@ function execute(command, args, {
   timeoutMs = 20 * 60 * 1_000,
   maxOutputBytes = 5 * 1024 * 1024,
   env,
+  signal,
 } = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
@@ -140,12 +149,20 @@ function execute(command, args, {
     const stderr = [];
     let bytes = 0;
     let timedOut = false;
+    let aborted = false;
     let stdinFailed = false;
     const timer = setTimeout(() => {
       timedOut = true;
       child.kill("SIGTERM");
       setTimeout(() => child.kill("SIGKILL"), 2_000).unref();
     }, timeoutMs);
+    const abort = () => {
+      aborted = true;
+      child.kill("SIGTERM");
+      setTimeout(() => child.kill("SIGKILL"), 2_000).unref();
+    };
+    if (signal?.aborted) abort();
+    else signal?.addEventListener("abort", abort, { once: true });
     const collect = target => chunk => {
       bytes += chunk.length;
       if (bytes <= maxOutputBytes) target.push(chunk);
@@ -155,16 +172,19 @@ function execute(command, args, {
     child.stderr.on("data", collect(stderr));
     child.on("error", error => {
       clearTimeout(timer);
+      signal?.removeEventListener("abort", abort);
       reject(error);
     });
     child.on("close", code => {
       clearTimeout(timer);
+      signal?.removeEventListener("abort", abort);
       const result = {
         code,
         stdout: Buffer.concat(stdout).toString("utf8"),
         stderr: Buffer.concat(stderr).toString("utf8"),
       };
-      if (timedOut) reject(new Error(`${command} timed out`));
+      if (aborted) reject(new Error(`${command} aborted`));
+      else if (timedOut) reject(new Error(`${command} timed out`));
       else if (stdinFailed) reject(new Error(`${command} closed before consuming its bounded input`));
       else if (bytes > maxOutputBytes) reject(new Error(`${command} output exceeded ${maxOutputBytes} bytes`));
       else if (code !== 0) reject(new Error(`${command} exited ${code}: ${result.stderr.trim().slice(0, 1_000)}`));
@@ -1402,7 +1422,7 @@ async function internalPublish(options) {
 }
 
 async function remoteLogs(options) {
-  exactOptions(options, ["deployment", "target", "proxmox", "host", "vmid", "run", "image", "json"]);
+  exactOptions(options, ["deployment", "target", "proxmox", "host", "vmid", "run", "image", "json", "follow"]);
   if (!NAME.test(options.deployment ?? "")) fail("--deployment is invalid");
   const runId = options.run ?? "latest";
   if (runId !== "latest" && !RUN_ID.test(runId)) fail("--run is invalid");
@@ -1411,6 +1431,10 @@ async function remoteLogs(options) {
   const image = options.image ?? DEFAULT_IMAGE;
   if (!IMAGE.test(image)) fail("--image is invalid");
   const hostRoot = deploymentRootForTarget(deploymentTarget, options.deployment);
+  if (options.follow) {
+    await followLogs(deploymentTarget, { hostRoot, image, runId, json: Boolean(options.json) });
+    return;
+  }
   const result = await targetExecute(deploymentTarget, [
     "docker", "run", "--rm", "--read-only", "--network", "none",
     "--user", "0:0",
@@ -1444,6 +1468,590 @@ async function internalLogs(argv) {
   process.stdout.write(await readFile(targetPath, "utf8"));
 }
 
+function internalStateRoot(options) {
+  const root = options["state-root"] ?? "/state";
+  if (typeof root !== "string" || root.length > 4_096 || !path.isAbsolute(root)
+      || path.normalize(root) !== root || /[\u0000\r\n]/u.test(root)) {
+    fail("--state-root is invalid");
+  }
+  return root;
+}
+
+function storedTimestamp(value) {
+  if (typeof value !== "string") return null;
+  const parsed = new Date(value);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString() === value ? value : null;
+}
+
+function parseEventLines(raw) {
+  let events;
+  try {
+    events = raw.split("\n").map(line => JSON.parse(line));
+  } catch {
+    fail("run event record is invalid");
+  }
+  if (events.some(event => !isPlainObject(event))) fail("run event record is invalid");
+  return events;
+}
+
+async function readRunEvents(runDir, { wholeFile }) {
+  const eventsPath = path.join(runDir, "events.jsonl");
+  const stat = await lstat(eventsPath).catch(() => null);
+  if (!stat) return [];
+  if (!stat.isFile() || stat.isSymbolicLink()) fail("run event record is invalid");
+  if (wholeFile) {
+    if (stat.size > 2 * 1024 * 1024) fail("run event record is invalid");
+    const raw = await readFile(eventsPath, "utf8");
+    return raw.trim() ? parseEventLines(raw.trimEnd()) : [];
+  }
+  const window = Math.min(stat.size, 128 * 1024);
+  if (!window) return [];
+  const handle = await open(eventsPath, "r");
+  try {
+    const buffer = Buffer.alloc(window);
+    await handle.read(buffer, 0, window, stat.size - window);
+    const text = buffer.toString("utf8").trimEnd();
+    const line = text ? text.split("\n").at(-1) : "";
+    return line ? parseEventLines(line) : [];
+  } finally {
+    await handle.close();
+  }
+}
+
+function summarizeEvent(event) {
+  if (!event) return null;
+  const summary = {};
+  if (Number.isSafeInteger(event.sequence)) summary.sequence = event.sequence;
+  const timestamp = storedTimestamp(event.timestamp);
+  if (timestamp) summary.timestamp = timestamp;
+  if (typeof event.type === "string" && /^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9]*)*$/.test(event.type)) {
+    summary.type = event.type;
+  }
+  for (const field of ["status", "reason", "role", "outcome", "template", "url", "phase"]) {
+    if (typeof event[field] === "string") {
+      summary[field] = event[field].replace(/[\u0000-\u001f\u007f]+/gu, " ").slice(0, 200);
+    }
+  }
+  return summary;
+}
+
+async function summarizeRun(stateRoot, runId, { withLastEvent = false } = {}) {
+  const runDir = path.join(stateRoot, runId);
+  const dirStat = await lstat(runDir);
+  if (!dirStat.isDirectory() || dirStat.isSymbolicLink()) fail("run directory is invalid");
+
+  let record = null;
+  const recordPath = path.join(runDir, "run.json");
+  const recordStat = await lstat(recordPath).catch(() => null);
+  if (recordStat) {
+    if (!recordStat.isFile() || recordStat.isSymbolicLink() || recordStat.size > 64 * 1024) {
+      fail("run record is invalid");
+    }
+    try {
+      record = JSON.parse(await readFile(recordPath, "utf8"));
+    } catch {
+      fail("run record is invalid");
+    }
+    if (!isPlainObject(record)) fail("run record is invalid");
+  }
+
+  let state = typeof record?.status === "string" && RUN_STATES.has(record.status) ? record.status : null;
+  let startedAt = storedTimestamp(record?.startedAt);
+  let finishedAt = storedTimestamp(record?.finishedAt);
+  let attempts = null;
+  if (Number.isSafeInteger(record?.currentAttempt) && record.currentAttempt >= 0) {
+    attempts = record.currentAttempt;
+  }
+  const phase = typeof record?.phase === "string" && record.phase.length <= 64 ? record.phase : null;
+
+  let events = [];
+  if (!state) events = await readRunEvents(runDir, { wholeFile: true });
+  else if (withLastEvent) events = await readRunEvents(runDir, { wholeFile: false });
+
+  if (!state) {
+    const terminal = events.at(-1);
+    if (terminal?.type === "run.finished" && RUN_STATES.has(terminal.status) && terminal.status !== "running") {
+      state = terminal.status;
+    } else if (terminal?.type === "run.failed") state = "failed";
+    else if (terminal?.type === "run.completed") state = "completed";
+    else state = "running";
+    startedAt ??= storedTimestamp(events[0]?.timestamp);
+    if (state !== "running") finishedAt ??= storedTimestamp(terminal?.timestamp);
+    attempts ??= events.reduce(
+      (maximum, event) => (Number.isSafeInteger(event.attempt) ? Math.max(maximum, event.attempt) : maximum),
+      0,
+    );
+  }
+  if (attempts === null) attempts = events.length ? 1 : 0;
+
+  return {
+    id: runId,
+    state,
+    phase,
+    startedAt,
+    finishedAt,
+    attempts,
+    ...(withLastEvent ? { lastEvent: summarizeEvent(events.at(-1) ?? null) } : {}),
+  };
+}
+
+async function internalRuns(argv) {
+  const { positional, options } = parseOptions(argv, { booleans: ["json"] });
+  if (positional.length) fail("internal-runs accepts no positional arguments");
+  exactOptions(options, ["deployment", "state-root", "json"]);
+  if (!NAME.test(options.deployment ?? "")) fail("--deployment is invalid");
+  const stateRoot = internalStateRoot(options);
+  const entries = await readdir(stateRoot, { withFileTypes: true });
+  const runIds = entries
+    .filter(entry => entry.isDirectory() && !entry.isSymbolicLink() && RUN_ID.test(entry.name))
+    .map(entry => entry.name);
+  if (runIds.length > RUN_SCAN_LIMIT) fail("run state exceeds the scan limit");
+  runIds.sort((left, right) => right.localeCompare(left));
+  const runs = [];
+  for (const runId of runIds.slice(0, RUN_LIST_LIMIT)) {
+    try {
+      runs.push(await summarizeRun(stateRoot, runId));
+    } catch {
+      runs.push({ id: runId, state: "unknown", phase: null, startedAt: null, finishedAt: null, attempts: 0 });
+    }
+  }
+  runs.sort((left, right) => (
+    (right.startedAt ?? "").localeCompare(left.startedAt ?? "") || right.id.localeCompare(left.id)
+  ));
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify({ deployment: options.deployment, runs })}\n`);
+    return;
+  }
+  for (const run of runs) {
+    process.stdout.write([
+      run.id,
+      run.state,
+      run.startedAt ?? "-",
+      run.finishedAt ?? "-",
+      String(run.attempts),
+    ].join("\t") + "\n");
+  }
+}
+
+async function internalStatus(argv) {
+  const { positional, options } = parseOptions(argv, { booleans: ["json"] });
+  if (positional.length) fail("internal-status accepts no positional arguments");
+  exactOptions(options, ["deployment", "run", "state-root", "json"]);
+  if (!NAME.test(options.deployment ?? "")) fail("--deployment is invalid");
+  const stateRoot = internalStateRoot(options);
+  let runId = options.run ?? "latest";
+  if (runId === "latest") runId = (await readFile(path.join(stateRoot, "latest"), "utf8").catch(() => "")).trim();
+  let status;
+  if (!runId) {
+    status = {
+      runId: null, state: "none", phase: null, startedAt: null, finishedAt: null, attempts: 0, lastEvent: null,
+    };
+  } else {
+    if (!RUN_ID.test(runId)) fail("invalid run ID");
+    const dirStat = await lstat(path.join(stateRoot, runId)).catch(() => null);
+    if (!dirStat?.isDirectory() || dirStat.isSymbolicLink()) fail(`unknown run: ${runId}`);
+    let summary;
+    try {
+      summary = await summarizeRun(stateRoot, runId, { withLastEvent: true });
+    } catch {
+      summary = {
+        id: runId, state: "unknown", phase: null, startedAt: null, finishedAt: null, attempts: 0, lastEvent: null,
+      };
+    }
+    const { id, ...rest } = summary;
+    status = { runId: id, ...rest };
+  }
+  const payload = { deployment: options.deployment, ...status };
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(payload)}\n`);
+    return;
+  }
+  const lines = [
+    `deployment: ${payload.deployment}`,
+    `run: ${payload.runId ?? "-"}`,
+    `state: ${payload.state}`,
+  ];
+  if (payload.phase) lines.push(`phase: ${payload.phase}`);
+  lines.push(`started: ${payload.startedAt ?? "-"}`);
+  lines.push(`finished: ${payload.finishedAt ?? "-"}`);
+  lines.push(`attempts: ${payload.attempts}`);
+  if (payload.lastEvent) {
+    lines.push(`last event: ${payload.lastEvent.type ?? "event"} at ${payload.lastEvent.timestamp ?? "-"}`);
+  }
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+async function internalTail(argv) {
+  const { positional, options } = parseOptions(argv);
+  if (positional.length) fail("internal-tail accepts no positional arguments");
+  exactOptions(options, ["run", "after", "state-root"]);
+  const stateRoot = internalStateRoot(options);
+  let runId = options.run ?? "latest";
+  if (runId === "latest") runId = (await readFile(path.join(stateRoot, "latest"), "utf8")).trim();
+  if (!RUN_ID.test(runId)) fail("invalid run ID");
+  if (!/^\d{1,15}$/.test(options.after ?? "0")) fail("--after is invalid");
+  let offset = Number(options.after ?? "0");
+  const eventsPath = path.join(stateRoot, runId, "events.jsonl");
+  const stat = await lstat(eventsPath).catch(() => null);
+  if (!stat?.isFile() || stat.isSymbolicLink()) fail(`unknown run: ${runId}`);
+  const size = stat.size;
+  if (offset > size) offset = 0;
+  const window = Math.min(TAIL_CHUNK_BYTES, size - offset);
+  let chunk = "";
+  let next = offset;
+  if (window > 0) {
+    const handle = await open(eventsPath, "r");
+    try {
+      const buffer = Buffer.alloc(window);
+      await handle.read(buffer, 0, window, offset);
+      const newline = buffer.lastIndexOf(0x0a);
+      if (newline >= 0) {
+        chunk = buffer.subarray(0, newline + 1).toString("utf8");
+        next = offset + newline + 1;
+      }
+    } finally {
+      await handle.close();
+    }
+  }
+  process.stdout.write(`${JSON.stringify({ runId, offset: next, size, chunk })}\n`);
+}
+
+function stateReadArgs(hostRoot, image, internalArgs) {
+  return [
+    "docker", "run", "--rm", "--read-only", "--network", "none",
+    "--user", "0:0",
+    "--cap-drop", "ALL",
+    "--security-opt", "no-new-privileges",
+    "--pids-limit", "64",
+    "--memory", "128m",
+    "--cpus", "0.25",
+    "--volume", `${hostRoot}/runs:/state:ro`,
+    image,
+    ...internalArgs,
+  ];
+}
+
+async function remoteRuns(options) {
+  exactOptions(options, ["deployment", "target", "proxmox", "host", "vmid", "image", "json"]);
+  if (!NAME.test(options.deployment ?? "")) fail("--deployment is invalid");
+  const deploymentTarget = resolveDeploymentTarget(options);
+  if (deploymentTarget.kind === "local") await requireLocalDocker();
+  const image = options.image ?? DEFAULT_IMAGE;
+  if (!IMAGE.test(image)) fail("--image is invalid");
+  const hostRoot = deploymentRootForTarget(deploymentTarget, options.deployment);
+  const result = await targetExecute(deploymentTarget, stateReadArgs(hostRoot, image, [
+    "internal-runs",
+    "--deployment", options.deployment,
+    ...(options.json ? ["--json"] : []),
+  ]), { maxOutputBytes: 2 * 1024 * 1024 });
+  process.stdout.write(result.stdout);
+}
+
+async function remoteStatus(options) {
+  exactOptions(options, ["deployment", "target", "proxmox", "host", "vmid", "run", "image", "json"]);
+  if (!NAME.test(options.deployment ?? "")) fail("--deployment is invalid");
+  const runId = options.run ?? "latest";
+  if (runId !== "latest" && !RUN_ID.test(runId)) fail("--run is invalid");
+  const deploymentTarget = resolveDeploymentTarget(options);
+  if (deploymentTarget.kind === "local") await requireLocalDocker();
+  const image = options.image ?? DEFAULT_IMAGE;
+  if (!IMAGE.test(image)) fail("--image is invalid");
+  const hostRoot = deploymentRootForTarget(deploymentTarget, options.deployment);
+  const result = await targetExecute(deploymentTarget, stateReadArgs(hostRoot, image, [
+    "internal-status",
+    "--deployment", options.deployment,
+    "--run", runId,
+    ...(options.json ? ["--json"] : []),
+  ]), { maxOutputBytes: 64 * 1024 });
+  process.stdout.write(result.stdout);
+}
+
+function formatFollowEvent(line) {
+  let event;
+  try {
+    event = JSON.parse(line);
+  } catch {
+    return line;
+  }
+  if (!isPlainObject(event)) return line;
+  const detail = event.status ?? event.reason
+    ?? (typeof event.role === "string"
+      ? [event.role, event.outcome].filter(value => typeof value === "string").join(" ")
+      : null)
+    ?? event.template ?? event.url ?? "";
+  const timestamp = typeof event.timestamp === "string" ? event.timestamp : "-";
+  const type = typeof event.type === "string" ? event.type : "event";
+  return `${timestamp} ${type}${detail ? ` ${String(detail).slice(0, 200)}` : ""}`;
+}
+
+function parseTailUpdate(stdout) {
+  let value;
+  try {
+    value = JSON.parse(stdout.trim().split("\n").at(-1));
+  } catch {
+    fail("follow update is invalid");
+  }
+  if (!isPlainObject(value) || !RUN_ID.test(value.runId ?? "")
+      || !Number.isSafeInteger(value.offset) || !Number.isSafeInteger(value.size)
+      || value.offset < 0 || value.offset > value.size
+      || typeof value.chunk !== "string" || Buffer.byteLength(value.chunk) > TAIL_CHUNK_BYTES) {
+    fail("follow update is invalid");
+  }
+  return value;
+}
+
+async function followLogs(deploymentTarget, { hostRoot, image, runId, json }) {
+  const abort = new AbortController();
+  let wake = null;
+  const stop = () => {
+    abort.abort();
+    wake?.();
+  };
+  process.once("SIGINT", stop);
+  process.once("SIGTERM", stop);
+  let offset = 0;
+  let currentRunId = null;
+  try {
+    while (!abort.signal.aborted) {
+      let update;
+      try {
+        const result = await targetExecute(deploymentTarget, stateReadArgs(hostRoot, image, [
+          "internal-tail",
+          "--run", currentRunId ?? runId,
+          "--after", String(offset),
+        ]), {
+          timeoutMs: 30_000,
+          maxOutputBytes: 256 * 1024,
+          signal: abort.signal,
+        });
+        update = parseTailUpdate(result.stdout);
+      } catch (error) {
+        if (abort.signal.aborted) break;
+        throw error;
+      }
+      currentRunId = update.runId;
+      offset = update.offset;
+      if (update.chunk) {
+        if (json) process.stdout.write(update.chunk);
+        else {
+          for (const line of update.chunk.trimEnd().split("\n")) {
+            process.stdout.write(`${formatFollowEvent(line)}\n`);
+          }
+        }
+      }
+      if (update.size > update.offset) continue;
+      await new Promise(resolve => {
+        const timer = setTimeout(() => {
+          wake = null;
+          resolve();
+        }, FOLLOW_POLL_MS);
+        wake = () => {
+          clearTimeout(timer);
+          resolve();
+        };
+      });
+    }
+  } finally {
+    process.off("SIGINT", stop);
+    process.off("SIGTERM", stop);
+  }
+}
+
+function doctorReason(error) {
+  return (error instanceof Error ? error.message : String(error))
+    .replace(/[\u0000-\u001f\u007f]+/gu, " ")
+    .trim()
+    .slice(0, 200) || "check failed";
+}
+
+async function nearestExistingDirectory(targetPath) {
+  let current = targetPath;
+  for (let depth = 0; depth < 64; depth += 1) {
+    const stat = await lstat(current).catch(() => null);
+    if (stat?.isDirectory() && !stat.isSymbolicLink()) return current;
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  fail("no existing directory on the state path");
+}
+
+function parseDfAvailable(stdout) {
+  const line = stdout.trim().split("\n").at(-1) ?? "";
+  const match = line.match(/(\d+)\s+\d+%\s+/);
+  if (!match) fail("df output is unparseable");
+  return Number(match[1]);
+}
+
+function doctorDiskReason(available) {
+  const mib = Math.floor(available / 1024);
+  if (available < DOCTOR_MIN_FREE_BLOCKS) fail(`only ${mib} MiB free`);
+  return `${mib} MiB free`;
+}
+
+async function doctorRemoteProbe(target, probe) {
+  return targetExecute(target, probe, { timeoutMs: 15_000, maxOutputBytes: 4 * 1024 })
+    .then(() => true, () => false);
+}
+
+async function doctorRemoteStateRoot(target, root) {
+  if (await doctorRemoteProbe(target, ["test", "-d", root])) {
+    if (!(await doctorRemoteProbe(target, ["test", "-w", root]))) fail("state root is not writable");
+    return `writable (${root})`;
+  }
+  const parent = path.posix.dirname(root);
+  if (await doctorRemoteProbe(target, ["test", "-d", parent, "-a", "-w", parent])) {
+    return `missing; parent is writable (${parent})`;
+  }
+  fail("state root is missing and its parent is not writable");
+}
+
+async function doctorRemoteDisk(target, root) {
+  let candidate = root;
+  for (let depth = 0; depth < 4; depth += 1) {
+    if (await doctorRemoteProbe(target, ["test", "-d", candidate])) {
+      const result = await targetExecute(target, ["df", "-Pk", candidate], {
+        timeoutMs: 15_000,
+        maxOutputBytes: 16 * 1024,
+      });
+      return doctorDiskReason(parseDfAvailable(result.stdout));
+    }
+    const parent = path.posix.dirname(candidate);
+    if (parent === candidate) break;
+    candidate = parent;
+  }
+  fail("no existing directory on the remote state path");
+}
+
+async function doctor(options) {
+  exactOptions(options, [
+    "deployment", "target", "proxmox", "host", "vmid", "secret-ref", "account", "json",
+  ]);
+  if (options.deployment !== undefined && !NAME.test(options.deployment)) fail("--deployment is invalid");
+  if (options["secret-ref"] !== undefined && !SECRET_REF.test(options["secret-ref"])) {
+    fail("--secret-ref must be a 1Password op:// reference");
+  }
+  const target = resolveDeploymentTarget(options);
+  const checks = [];
+  const check = async (name, run) => {
+    try {
+      checks.push(Object.freeze({ name, status: "pass", reason: await run() }));
+    } catch (error) {
+      checks.push(Object.freeze({ name, status: "fail", reason: doctorReason(error) }));
+    }
+  };
+
+  if (target.kind === "local") {
+    await check("docker", async () => {
+      const status = await inspectLocalDocker();
+      if (status.availability !== "ready") fail(status.reason);
+      return `ready (${status.platform})`;
+    });
+    const root = options.deployment
+      ? deploymentRootForTarget(target, options.deployment)
+      : deploymentsRootForTarget(target);
+    await check("state-root", async () => {
+      const existing = await nearestExistingDirectory(root);
+      await access(existing, fsConstants.W_OK);
+      return `writable (${existing})`;
+    });
+    await check("disk", async () => {
+      const existing = await nearestExistingDirectory(root);
+      const result = await execute("df", ["-Pk", existing], {
+        timeoutMs: 15_000,
+        maxOutputBytes: 16 * 1024,
+      });
+      return doctorDiskReason(parseDfAvailable(result.stdout));
+    });
+  } else {
+    const sshTarget = target.kind === "ssh"
+      ? target
+      : Object.freeze({ kind: "ssh", runtime: "docker", sshTarget: target.sshTarget });
+    await check("ssh", async () => {
+      await targetExecute(sshTarget, ["true"], { timeoutMs: 15_000, maxOutputBytes: 4 * 1024 });
+      return "reachable (batch mode)";
+    });
+    if (target.kind === "proxmox-lxc") {
+      await check("pct", async () => {
+        const result = await targetExecute(sshTarget, ["pct", "status", target.vmid], {
+          timeoutMs: 15_000,
+          maxOutputBytes: 4 * 1024,
+        });
+        const status = result.stdout.trim();
+        if (!/^status: running$/u.test(status)) fail(`guest ${target.vmid} is not running`);
+        return `guest ${target.vmid} is running`;
+      });
+    }
+    await check("docker", async () => {
+      const result = await targetExecute(target, [
+        "docker", "version", "--format", "{{.Server.Os}}/{{.Server.Arch}}",
+      ], { timeoutMs: 15_000, maxOutputBytes: 4 * 1024 });
+      const platform = result.stdout.trim();
+      if (!/^linux\/(?:amd64|arm64)$/u.test(platform)) {
+        fail("remote Docker platform must be linux/amd64 or linux/arm64");
+      }
+      return `ready (${platform})`;
+    });
+    const root = options.deployment
+      ? deploymentRootForTarget(target, options.deployment)
+      : deploymentsRootForTarget(target);
+    await check("state-root", () => doctorRemoteStateRoot(target, root));
+    await check("disk", () => doctorRemoteDisk(target, root));
+  }
+
+  if (options["secret-ref"]) {
+    let opAvailable = false;
+    await check("op-cli", async () => {
+      const result = await execute("op", ["--version"], {
+        timeoutMs: 15_000,
+        maxOutputBytes: 4 * 1024,
+      });
+      const version = result.stdout.trim();
+      if (!/^\d+\.\d+[\d.]*$/u.test(version)) fail("op CLI returned an unexpected version");
+      opAvailable = true;
+      return `op ${version}`;
+    });
+    if (opAvailable) {
+      await check("secret-ref", async () => {
+        const args = ["read", options["secret-ref"]];
+        if (options.account) args.push("--account", options.account);
+        const result = await execute("op", args, {
+          timeoutMs: 15_000,
+          maxOutputBytes: 4 * 1024,
+        }).catch(() => fail("reference is not readable"));
+        if (!result.stdout.trim()) fail("reference resolved to an empty value");
+        return "reference is readable";
+      });
+    } else {
+      checks.push(Object.freeze({ name: "secret-ref", status: "skip", reason: "op CLI is unavailable" }));
+    }
+  } else {
+    checks.push(Object.freeze({ name: "secret-ref", status: "skip", reason: "no --secret-ref supplied" }));
+  }
+
+  const ok = checks.every(entry => entry.status !== "fail");
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify({ ok, target: target.kind, checks })}\n`);
+  } else {
+    for (const entry of checks) {
+      process.stdout.write(`${entry.status.toUpperCase()} ${entry.name}: ${entry.reason}\n`);
+    }
+  }
+  if (!ok) process.exitCode = 1;
+}
+
+const COMMAND_HELP = {
+  list: "bimo list [--json]\n  List the installed workflow and pod templates.",
+  targets: "bimo targets [--json]\n  Probe the local Docker daemon and list the built-in deployment targets.",
+  validate: "bimo validate TEMPLATE [--json]\n  Validate one installed template and print its digest.",
+  organize: "bimo organize -p PROMPT [-n 1|2|3] --deployment NAME [target flags] --secret-ref op://VAULT/ITEM/FIELD [--json]\n  Plan a deployment with bounded organizer agents without deploying.",
+  deploy: "bimo deploy TEMPLATE --deployment NAME [target flags] --task-file FILE --secret-ref op://VAULT/ITEM/FIELD [--json]\n  Deploy a template as a bounded Docker fleet.",
+  runs: "bimo runs --deployment NAME [target flags] [--json]\n  List recorded runs for a deployment from its durable state root.",
+  status: "bimo status --deployment NAME [target flags] [--run ID] [--json]\n  Print the latest run state and last event for a deployment.",
+  logs: "bimo logs --deployment NAME [target flags] [--run ID] [--json] [--follow]\n  Print a run log; --follow streams new events until interrupted.",
+  doctor: "bimo doctor [--deployment NAME] [target flags] [--secret-ref op://VAULT/ITEM/FIELD] [--json]\n  Run deployment preflight checks and report pass, fail, or skip per check.",
+};
+
 function usage() {
   return `usage:
   bimo list [--json]
@@ -1453,7 +2061,11 @@ function usage() {
   bimo -p PROMPT [-n 1|2|3] --deployment NAME [--target local | --target ssh --host HOST | --target proxmox-lxc --proxmox HOST --vmid ID] --secret-ref op://VAULT/ITEM/FIELD [--json]
   bimo deploy TEMPLATE --deployment NAME [--target local | --target ssh --host HOST | --target proxmox-lxc --proxmox HOST --vmid ID] --task-file FILE --secret-ref op://VAULT/ITEM/FIELD --public-url URL [--json]
   bimo deploy parallel-engineering-pod --deployment NAME [--target local | --target ssh --host HOST | --target proxmox-lxc --proxmox HOST --vmid ID] --task-file FILE --secret-ref op://VAULT/ITEM/FIELD --github-secret-ref op://VAULT/ITEM/FIELD --repository ${POD_REPOSITORY} --base-sha SHA --target-branch main [--json]
-  bimo logs --deployment NAME [--target local | --target ssh --host HOST | --target proxmox-lxc --proxmox HOST --vmid ID] [--run ID] [--json]
+  bimo logs --deployment NAME [--target local | --target ssh --host HOST | --target proxmox-lxc --proxmox HOST --vmid ID] [--run ID] [--json] [--follow]
+  bimo runs --deployment NAME [--target local | --target ssh --host HOST | --target proxmox-lxc --proxmox HOST --vmid ID] [--json]
+  bimo status --deployment NAME [--target local | --target ssh --host HOST | --target proxmox-lxc --proxmox HOST --vmid ID] [--run ID] [--json]
+  bimo doctor [--deployment NAME] [--target local | --target ssh --host HOST | --target proxmox-lxc --proxmox HOST --vmid ID] [--secret-ref op://VAULT/ITEM/FIELD] [--json]
+  bimo help [COMMAND]
 `;
 }
 
@@ -1469,12 +2081,22 @@ export async function main(argv = process.argv.slice(2)) {
     return;
   }
   if (command === "help" || command === "--help" || command === "-h") {
+    const topic = command === "help" ? rest[0] : undefined;
+    if (topic !== undefined) {
+      if (rest.length !== 1 || !Object.hasOwn(COMMAND_HELP, topic)) fail(`unknown command: ${topic}`);
+      process.stdout.write(`${COMMAND_HELP[topic]}\n`);
+      return;
+    }
     process.stdout.write(usage());
     return;
   }
   if (command === "--version") {
     const manifest = JSON.parse(await readFile(path.join(packageRoot, "package.json"), "utf8"));
     process.stdout.write(`${manifest.version}\n`);
+    return;
+  }
+  if (rest.includes("--help") && Object.hasOwn(COMMAND_HELP, command)) {
+    process.stdout.write(`${COMMAND_HELP[command]}\n`);
     return;
   }
   if (command === "list") {
@@ -1523,9 +2145,27 @@ export async function main(argv = process.argv.slice(2)) {
     return;
   }
   if (command === "logs") {
-    const { positional, options } = parseOptions(rest, { booleans: ["json"] });
+    const { positional, options } = parseOptions(rest, { booleans: ["json", "follow"] });
     if (positional.length) fail("logs accepts no positional arguments");
     await remoteLogs(options);
+    return;
+  }
+  if (command === "runs") {
+    const { positional, options } = parseOptions(rest, { booleans: ["json"] });
+    if (positional.length) fail("runs accepts no positional arguments");
+    await remoteRuns(options);
+    return;
+  }
+  if (command === "status") {
+    const { positional, options } = parseOptions(rest, { booleans: ["json"] });
+    if (positional.length) fail("status accepts no positional arguments");
+    await remoteStatus(options);
+    return;
+  }
+  if (command === "doctor") {
+    const { positional, options } = parseOptions(rest, { booleans: ["json"] });
+    if (positional.length) fail("doctor accepts no positional arguments");
+    await doctor(options);
     return;
   }
   if (command === "internal-run") {
@@ -1560,6 +2200,18 @@ export async function main(argv = process.argv.slice(2)) {
   }
   if (command === "internal-logs") {
     await internalLogs(rest);
+    return;
+  }
+  if (command === "internal-runs") {
+    await internalRuns(rest);
+    return;
+  }
+  if (command === "internal-status") {
+    await internalStatus(rest);
+    return;
+  }
+  if (command === "internal-tail") {
+    await internalTail(rest);
     return;
   }
   fail(`unknown command: ${command}`);

--- a/src/deployment-target.mjs
+++ b/src/deployment-target.mjs
@@ -112,6 +112,12 @@ export function deploymentRootForTarget(target, deployment) {
   return path.join(validateLocalHome(target.home ?? os.homedir()), ...LOCAL_ROOT_PARTS, deployment);
 }
 
+export function deploymentsRootForTarget(target) {
+  if (!target || !TARGET_KINDS.includes(target.kind)) fail("invalid deployment target root");
+  if (target.kind !== "local") return REMOTE_ROOT;
+  return path.join(validateLocalHome(target.home ?? os.homedir()), ...LOCAL_ROOT_PARTS);
+}
+
 export function isDeploymentHostRoot(hostRoot, deployment, { localHome } = {}) {
   if (typeof hostRoot !== "string" || hostRoot.length > 4_096
       || !NAME.test(deployment ?? "") || !path.isAbsolute(hostRoot)

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { execFile, spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { EventEmitter } from "node:events";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import { tmpdir } from "node:os";
 import { promisify } from "node:util";
@@ -149,11 +149,24 @@ const fs = require("node:fs");
 const { createHash } = require("node:crypto");
 const args = process.argv.slice(2);
 const command = args.slice(5);
-const dockerIndex = command.indexOf("docker");
-const runtimeCommand = dockerIndex === -1 ? command : command.slice(dockerIndex);
+const separator = command.indexOf("--");
+const runtimeCommand = separator === -1 ? command : command.slice(separator + 1);
 const log = value => fs.appendFileSync(process.env.BIMO_TEST_LOG, JSON.stringify(value) + "\\n");
 log({ tool: "ssh", args, command });
-if (runtimeCommand[0] === "docker" && runtimeCommand[1] === "version") {
+if (runtimeCommand[0] === "true" || runtimeCommand[0] === "test") {
+  process.exit(0);
+} else if (runtimeCommand[0] === "df") {
+  process.stdout.write("Filesystem 1024-blocks Used Available Capacity Mounted on\\n/dev/disk1 488245288 10000000 470000000 3% /\\n");
+} else if (runtimeCommand[0] === "pct") {
+  process.stdout.write(process.env.BIMO_TEST_PCT_STATUS ?? "status: running\\n");
+} else if (runtimeCommand[0] === "docker" && runtimeCommand[1] === "run"
+    && (runtimeCommand.includes("internal-runs") || runtimeCommand.includes("internal-status")
+      || runtimeCommand.includes("internal-tail"))) {
+  const payload = runtimeCommand.includes("internal-runs") ? process.env.BIMO_TEST_RUNS_OUTPUT
+    : runtimeCommand.includes("internal-status") ? process.env.BIMO_TEST_STATUS_OUTPUT
+    : process.env.BIMO_TEST_TAIL_OUTPUT;
+  process.stdout.write(payload ?? "");
+} else if (runtimeCommand[0] === "docker" && runtimeCommand[1] === "version") {
   process.stdout.write(process.env.BIMO_TEST_REMOTE_PLATFORM + "\\n");
 } else if (runtimeCommand[0] === "docker" && runtimeCommand[1] === "load") {
   process.stdin.resume();
@@ -268,9 +281,12 @@ if (runtimeCommand[0] === "docker" && runtimeCommand[1] === "version") {
   const op = `#!/usr/bin/env node
 const fs = require("node:fs");
 const args = process.argv.slice(2);
-fs.appendFileSync(process.env.BIMO_TEST_LOG, JSON.stringify({ tool: "op", reference: args[1] }) + "\\n");
-if (args[1].endsWith("/github")) process.stdout.write("github_pat_${"g".repeat(64)}\\n");
-else process.stdout.write("sk-or-v1-${"k".repeat(32)}\\n");
+if (args[0] === "--version") process.stdout.write("2.30.0\\n");
+else {
+  fs.appendFileSync(process.env.BIMO_TEST_LOG, JSON.stringify({ tool: "op", reference: args[1] }) + "\\n");
+  if (args[1].endsWith("/github")) process.stdout.write("github_pat_${"g".repeat(64)}\\n");
+  else process.stdout.write("sk-or-v1-${"k".repeat(32)}\\n");
+}
 `;
   await Promise.all([
     writeFile(path.join(directory, "docker"), docker, { mode: 0o755 }),
@@ -1219,4 +1235,360 @@ test("pod controller composition starts without app bootstrap and verifies only 
   assert.deepEqual(Object.keys(verification.candidateSnapshot).sort(), ["id", "receipt", "sha"]);
   assert.deepEqual(Object.keys(verification.baseSnapshot).sort(), ["id", "receipt", "sha"]);
   assert.equal(calls.at(-1)[0], "close");
+});
+
+async function fakeStateRoot(t) {
+  const directory = await mkdtemp(path.join(tmpdir(), "bimo-state-test-"));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  const workflowRun = "20240101000000-aaaa1111";
+  const podRun = "20240202000000-bbbb2222";
+  await mkdir(path.join(directory, workflowRun));
+  await mkdir(path.join(directory, podRun));
+  await writeFile(path.join(directory, workflowRun, "events.jsonl"), [
+    JSON.stringify({
+      version: 1, sequence: 1, timestamp: "2024-01-01T00:00:00.000Z", runId: workflowRun, type: "run.started",
+    }),
+    JSON.stringify({
+      version: 1, sequence: 2, timestamp: "2024-01-01T00:01:00.000Z", runId: workflowRun,
+      type: "role.started", role: "engineering", step: 1, attempt: 1,
+    }),
+    JSON.stringify({
+      version: 1, sequence: 3, timestamp: "2024-01-01T00:02:00.000Z", runId: workflowRun,
+      type: "run.finished", status: "completed", steps: 1,
+    }),
+  ].join("\n") + "\n");
+  await writeFile(path.join(directory, podRun, "run.json"), `${JSON.stringify({
+    version: 1,
+    runId: podRun,
+    assignment: {},
+    status: "running",
+    phase: "planned",
+    currentAttempt: 2,
+    startedAt: "2024-02-02T00:00:00.000Z",
+    finishedAt: null,
+  }, null, 2)}\n`);
+  await writeFile(path.join(directory, podRun, "events.jsonl"), "");
+  await writeFile(path.join(directory, "latest"), `${workflowRun}\n`);
+  return { directory, workflowRun, podRun };
+}
+
+test("internal-runs summarizes recorded runs newest first in JSON and text", async t => {
+  const { directory, workflowRun, podRun } = await fakeStateRoot(t);
+  const result = await invoke(["internal-runs", "--state-root", directory, "--deployment", "demo", "--json"]);
+  assert.equal(result.code, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    deployment: "demo",
+    runs: [
+      {
+        id: podRun,
+        state: "running",
+        phase: "planned",
+        startedAt: "2024-02-02T00:00:00.000Z",
+        finishedAt: null,
+        attempts: 2,
+      },
+      {
+        id: workflowRun,
+        state: "completed",
+        phase: null,
+        startedAt: "2024-01-01T00:00:00.000Z",
+        finishedAt: "2024-01-01T00:02:00.000Z",
+        attempts: 1,
+      },
+    ],
+  });
+
+  const text = await invoke(["internal-runs", "--state-root", directory, "--deployment", "demo"]);
+  assert.equal(text.code, 0, text.stderr);
+  assert.equal(text.stdout, [
+    `${podRun}\trunning\t2024-02-02T00:00:00.000Z\t-\t2`,
+    `${workflowRun}\tcompleted\t2024-01-01T00:00:00.000Z\t2024-01-01T00:02:00.000Z\t1`,
+    "",
+  ].join("\n"));
+});
+
+test("internal-runs isolates corrupt runs instead of hiding healthy ones", async t => {
+  const { directory, workflowRun } = await fakeStateRoot(t);
+  const corrupt = "20240303000000-cccc3333";
+  await mkdir(path.join(directory, corrupt));
+  await writeFile(path.join(directory, corrupt, "events.jsonl"), "not json\n");
+  const result = await invoke(["internal-runs", "--state-root", directory, "--deployment", "demo", "--json"]);
+  assert.equal(result.code, 0, result.stderr);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.runs.length, 3);
+  const corrupted = payload.runs.find(run => run.id === corrupt);
+  assert.equal(corrupted.state, "unknown");
+  assert.ok(payload.runs.some(run => run.id === workflowRun && run.state === "completed"));
+});
+
+test("internal-status reports the latest run state and last event", async t => {
+  const { directory, workflowRun } = await fakeStateRoot(t);
+  const result = await invoke(["internal-status", "--state-root", directory, "--deployment", "demo", "--json"]);
+  assert.equal(result.code, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    deployment: "demo",
+    runId: workflowRun,
+    state: "completed",
+    phase: null,
+    startedAt: "2024-01-01T00:00:00.000Z",
+    finishedAt: "2024-01-01T00:02:00.000Z",
+    attempts: 1,
+    lastEvent: {
+      sequence: 3,
+      timestamp: "2024-01-01T00:02:00.000Z",
+      type: "run.finished",
+      status: "completed",
+    },
+  });
+
+  const text = await invoke(["internal-status", "--state-root", directory, "--deployment", "demo"]);
+  assert.equal(text.code, 0, text.stderr);
+  assert.match(text.stdout, /state: completed/);
+  assert.match(text.stdout, /last event: run\.finished at 2024-01-01T00:02:00\.000Z/);
+
+  const empty = await mkdtemp(path.join(tmpdir(), "bimo-state-empty-"));
+  t.after(() => rm(empty, { recursive: true, force: true }));
+  const none = await invoke(["internal-status", "--state-root", empty, "--deployment", "demo", "--json"]);
+  assert.equal(none.code, 0, none.stderr);
+  assert.equal(JSON.parse(none.stdout).state, "none");
+});
+
+test("internal-tail streams complete event lines from a byte offset", async t => {
+  const { directory, workflowRun } = await fakeStateRoot(t);
+  const first = await invoke(["internal-tail", "--state-root", directory, "--run", "latest", "--after", "0"]);
+  assert.equal(first.code, 0, first.stderr);
+  const update = JSON.parse(first.stdout);
+  assert.equal(update.runId, workflowRun);
+  assert.equal(update.offset, update.size);
+  assert.equal(update.chunk.trimEnd().split("\n").length, 3);
+
+  const eventsPath = path.join(directory, workflowRun, "events.jsonl");
+  const extra = JSON.stringify({
+    version: 1, sequence: 4, timestamp: "2024-01-01T00:03:00.000Z", runId: workflowRun,
+    type: "role.failed", role: "engineering", reason: "boom",
+  }) + "\n";
+  await appendFile(eventsPath, extra);
+  const second = await invoke([
+    "internal-tail", "--state-root", directory, "--run", workflowRun, "--after", String(update.offset),
+  ]);
+  assert.equal(second.code, 0, second.stderr);
+  const follow = JSON.parse(second.stdout);
+  assert.equal(follow.chunk, extra);
+  assert.equal(follow.offset, update.offset + Buffer.byteLength(extra));
+
+  const clamped = await invoke([
+    "internal-tail", "--state-root", directory, "--run", workflowRun, "--after", "999999999",
+  ]);
+  assert.equal(clamped.code, 0, clamped.stderr);
+  const reset = JSON.parse(clamped.stdout);
+  assert.equal(reset.offset, reset.size);
+  assert.ok(reset.chunk.startsWith('{"version":1,"sequence":1'));
+
+  const invalid = await invoke([
+    "internal-tail", "--state-root", directory, "--run", workflowRun, "--after", "-1",
+  ]);
+  assert.equal(invalid.code, 1);
+  assert.match(invalid.stderr, /--after is invalid/);
+});
+
+test("runs and status read the state root through the sandboxed read container", async t => {
+  const tools = await fakeDeployTools(t);
+  const runsPayload = `${JSON.stringify({ deployment: "fleet-demo", runs: [] })}\n`;
+  const runs = await invoke([
+    "runs", "--deployment", "fleet-demo", "--host", "example.invalid",
+    "--image", "bimo-workflow:test", "--json",
+  ], { env: { ...tools.env, BIMO_TEST_RUNS_OUTPUT: runsPayload } });
+  assert.equal(runs.code, 0, runs.stderr);
+  assert.equal(runs.stdout, runsPayload);
+
+  const statusPayload = `${JSON.stringify({
+    deployment: "fleet-demo", runId: null, state: "none", phase: null,
+    startedAt: null, finishedAt: null, attempts: 0, lastEvent: null,
+  })}\n`;
+  const status = await invoke([
+    "status", "--deployment", "fleet-demo", "--host", "example.invalid",
+    "--image", "bimo-workflow:test", "--json",
+  ], { env: { ...tools.env, BIMO_TEST_STATUS_OUTPUT: statusPayload } });
+  assert.equal(status.code, 0, status.stderr);
+  assert.equal(status.stdout, statusPayload);
+
+  const commands = (await readCommandLog(tools.logFile))
+    .filter(entry => entry.tool === "ssh")
+    .map(entry => entry.command);
+  const runsCommand = commands.find(command => command.includes("internal-runs"));
+  const statusCommand = commands.find(command => command.includes("internal-status"));
+  assert.ok(runsCommand);
+  assert.ok(statusCommand);
+  for (const command of [runsCommand, statusCommand]) {
+    assert.ok(command.includes("/var/lib/bimo/deployments/fleet-demo/runs:/state:ro"));
+    assert.ok(command.includes("--network"));
+    assert.ok(command.includes("--read-only"));
+  }
+  assert.deepEqual(runsCommand.slice(-3), ["--deployment", "fleet-demo", "--json"]);
+  assert.deepEqual(statusCommand.slice(-5), ["--deployment", "fleet-demo", "--run", "latest", "--json"]);
+});
+
+test("logs --follow streams new events and exits cleanly on SIGINT", async t => {
+  const tools = await fakeDeployTools(t);
+  const chunk = `${JSON.stringify({
+    version: 1, sequence: 1, timestamp: "2024-01-01T00:00:00.000Z", runId: "run-1", type: "run.started",
+  })}\n${JSON.stringify({
+    version: 1, sequence: 2, timestamp: "2024-01-01T00:01:00.000Z", runId: "run-1",
+    type: "run.finished", status: "completed",
+  })}\n`;
+  const payload = `${JSON.stringify({
+    runId: "run-1", offset: Buffer.byteLength(chunk), size: Buffer.byteLength(chunk), chunk,
+  })}\n`;
+  const child = spawn(process.execPath, [
+    cli, "logs", "--deployment", "fleet-demo", "--host", "example.invalid",
+    "--image", "bimo-workflow:test", "--follow",
+  ], {
+    cwd: root,
+    env: { ...tools.env, BIMO_TEST_TAIL_OUTPUT: payload },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const stdout = [];
+  const stderr = [];
+  let interrupted = false;
+  const killer = setTimeout(() => child.kill("SIGKILL"), 10_000);
+  child.stdout.on("data", data => {
+    stdout.push(data);
+    if (!interrupted) {
+      interrupted = true;
+      child.kill("SIGINT");
+    }
+  });
+  child.stderr.on("data", data => stderr.push(data));
+  const code = await new Promise(resolve => child.on("close", resolve));
+  clearTimeout(killer);
+  assert.equal(code, 0);
+  const output = Buffer.concat(stdout).toString("utf8");
+  assert.ok(output.includes("2024-01-01T00:00:00.000Z run.started"));
+  assert.ok(output.includes("2024-01-01T00:01:00.000Z run.finished completed"));
+  assert.equal(Buffer.concat(stderr).toString("utf8"), "");
+
+  const entries = await readCommandLog(tools.logFile);
+  const tail = entries.find(entry => entry.tool === "ssh" && entry.command.includes("internal-tail"));
+  assert.ok(tail);
+  assert.deepEqual(tail.command.slice(-4), ["--run", "latest", "--after", "0"]);
+});
+
+test("doctor runs local preflight checks and skips credentials without --secret-ref", async t => {
+  const tools = await fakeDeployTools(t);
+  const result = await invoke(["doctor", "--json"], { env: tools.env });
+  assert.equal(result.code, 0, result.stderr);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.ok, true);
+  assert.equal(report.target, "local");
+  assert.deepEqual(report.checks.map(check => [check.name, check.status]), [
+    ["docker", "pass"],
+    ["state-root", "pass"],
+    ["disk", "pass"],
+    ["secret-ref", "skip"],
+  ]);
+  assert.match(report.checks[0].reason, /linux\/arm64/);
+});
+
+test("doctor exits 1 and reports the failing check when the daemon is unusable", async t => {
+  const tools = await fakeDeployTools(t);
+  const result = await invoke(["doctor", "--json"], {
+    env: { ...tools.env, BIMO_TEST_DOCKER_ENDPOINT: "tcp://docker.example:2376" },
+  });
+  assert.equal(result.code, 1);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.ok, false);
+  assert.equal(report.checks[0].name, "docker");
+  assert.equal(report.checks[0].status, "fail");
+  assert.match(report.checks[0].reason, /Unix socket/);
+});
+
+test("doctor checks ssh targets and credential readability without printing secrets", async t => {
+  const tools = await fakeDeployTools(t);
+  const result = await invoke([
+    "doctor", "--deployment", "fleet-demo", "--host", "example.invalid",
+    "--secret-ref", "op://Test/Bimo/openrouter", "--json",
+  ], { env: tools.env });
+  assert.equal(result.code, 0, result.stderr);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.ok, true);
+  assert.deepEqual(report.checks.map(check => [check.name, check.status]), [
+    ["ssh", "pass"],
+    ["docker", "pass"],
+    ["state-root", "pass"],
+    ["disk", "pass"],
+    ["op-cli", "pass"],
+    ["secret-ref", "pass"],
+  ]);
+  const secret = `sk-or-v1-${"k".repeat(32)}`;
+  assert.equal(result.stdout.includes(secret), false);
+  assert.equal(JSON.stringify(await readCommandLog(tools.logFile)).includes(secret), false);
+});
+
+test("doctor checks proxmox reachability, guest status, and in-guest docker", async t => {
+  const tools = await fakeDeployTools(t);
+  const result = await invoke([
+    "doctor", "--target", "proxmox-lxc", "--proxmox", "root@pve-05", "--vmid", "212", "--json",
+  ], { env: tools.env });
+  assert.equal(result.code, 0, result.stderr);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.ok, true);
+  assert.deepEqual(report.checks.map(check => check.name), [
+    "ssh", "pct", "docker", "state-root", "disk", "secret-ref",
+  ]);
+  const commands = (await readCommandLog(tools.logFile))
+    .filter(entry => entry.tool === "ssh")
+    .map(entry => entry.command);
+  assert.ok(commands.some(command => command.join(" ") === "pct status 212"));
+  assert.ok(commands.some(command => command.slice(0, 5).join(" ") === "pct exec 212 -- docker"));
+
+  const stopped = await invoke([
+    "doctor", "--target", "proxmox-lxc", "--proxmox", "root@pve-05", "--vmid", "212", "--json",
+  ], { env: { ...tools.env, BIMO_TEST_PCT_STATUS: "status: stopped\n" } });
+  assert.equal(stopped.code, 1);
+  const stoppedReport = JSON.parse(stopped.stdout);
+  assert.equal(stoppedReport.ok, false);
+  assert.deepEqual(
+    stoppedReport.checks.find(check => check.name === "pct").status,
+    "fail",
+  );
+});
+
+test("help prints per-command synopses while --help keeps the full usage", async () => {
+  const full = await invoke(["--help"]);
+  const bare = await invoke(["help"]);
+  assert.equal(bare.code, 0);
+  assert.equal(bare.stdout, full.stdout);
+
+  const logsHelp = await invoke(["help", "logs"]);
+  assert.equal(logsHelp.code, 0, logsHelp.stderr);
+  assert.match(logsHelp.stdout, /^bimo logs --deployment NAME/);
+  const flagHelp = await invoke(["logs", "--help"]);
+  assert.equal(flagHelp.code, 0, flagHelp.stderr);
+  assert.equal(flagHelp.stdout, logsHelp.stdout);
+  for (const command of ["runs", "status", "doctor", "deploy", "organize", "list", "targets", "validate"]) {
+    const result = await invoke(["help", command]);
+    assert.equal(result.code, 0, `${command}: ${result.stderr}`);
+    assert.match(result.stdout, new RegExp(`^bimo ${command} `));
+  }
+
+  const bogus = await invoke(["help", "bogus"]);
+  assert.equal(bogus.code, 1);
+  assert.match(bogus.stderr, /unknown command: bogus/);
+});
+
+test("runs, status, logs --follow, and doctor reject invalid options before Docker", async t => {
+  const tools = await fakeDeployTools(t);
+  for (const [args, pattern] of [
+    [["runs"], /--deployment is invalid/],
+    [["runs", "--deployment", "Fleet_Demo"], /--deployment is invalid/],
+    [["status", "--deployment", "fleet-demo", "--run", "$(id)"], /--run is invalid/],
+    [["logs", "--deployment", "fleet-demo", "--follow", "--run", "latest;id"], /--run is invalid/],
+    [["doctor", "--secret-ref", "not-a-secret"], /--secret-ref must be a 1Password op:\/\/ reference/],
+    [["runs", "--deployment", "fleet-demo", "--unknown", "value"], /unknown option: --unknown/],
+  ]) {
+    const result = await invoke(args, { env: tools.env });
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, pattern);
+  }
+  assert.deepEqual(await readCommandLog(tools.logFile), []);
 });

--- a/test/deployment-target.test.mjs
+++ b/test/deployment-target.test.mjs
@@ -7,6 +7,7 @@ import test from "node:test";
 import {
   commandForTarget,
   deploymentRootForTarget,
+  deploymentsRootForTarget,
   isDeploymentHostRoot,
   resolveDeploymentTarget,
 } from "../src/deployment-target.mjs";
@@ -125,4 +126,21 @@ test("controller host roots accept only canonical remote or local deployment roo
     }),
     false,
   );
+});
+
+test("deploymentsRootForTarget returns the shared deployments root per adapter", () => {
+  const home = os.homedir();
+  assert.equal(
+    deploymentsRootForTarget(resolveDeploymentTarget({}, { home })),
+    path.join(home, ".local", "share", "bimo", "deployments"),
+  );
+  assert.equal(
+    deploymentsRootForTarget(resolveDeploymentTarget({ host: "builder.example" })),
+    "/var/lib/bimo/deployments",
+  );
+  assert.equal(
+    deploymentsRootForTarget(resolveDeploymentTarget({ proxmox: "root@pve-05", vmid: "212" })),
+    "/var/lib/bimo/deployments",
+  );
+  assert.throws(() => deploymentsRootForTarget({ kind: "other" }), /invalid deployment target root/);
 });


### PR DESCRIPTION
Refs #7

Operator recovery track: supported run discovery/diagnosis, preflight checks, and subcommand-level help.

- [x] `bimo runs --deployment NAME [target flags] [--json]` — lists recorded runs (id, state, started/finished, attempt count) from the durable state root, newest first, capped at 50, via the existing sandboxed read-only container pattern. Corrupt runs degrade to `unknown` without hiding healthy ones.
- [x] `bimo status --deployment NAME [target flags] [--run ID] [--json]` — current deployment state: latest run's state/phase/started/finished/attempts plus a bounded last-event summary; reports `none` when no run is recorded.
- [x] `bimo logs --deployment NAME [--run ID] [--follow]` — follow mode replays the run's events from the start, then polls `internal-tail` every 2s for byte-offset chunks of `events.jsonl` and streams new events (raw JSONL with `--json`, one-line rendering otherwise) until a clean SIGINT/SIGTERM exit 0. Non-follow output is byte-identical to before.
- [x] `bimo doctor [--deployment NAME] [target flags] [--secret-ref op://...] [--json]` — preflight per target: local docker reachability/platform; SSH batch-mode reachability, remote docker, state-root writability, and `df` disk headroom for ssh; pct reachability, guest running, and in-guest docker for proxmox-lxc; `op` CLI presence and secret-ref readability (value captured and discarded, never printed). Each check reports pass/fail/skip with a one-line reason; exit 0 only when all applicable checks pass.
- [x] `bimo help COMMAND` and `bimo COMMAND --help` print per-command synopses; bare `bimo help`/`--help` keeps the full usage.

Internals: new `internal-runs`/`internal-status`/`internal-tail` container commands (accept `--state-root` for direct testing), `deploymentsRootForTarget` export, and an abort `signal` option on the shared `execute` helper used by follow mode.

Tests: 218 → 231, all green; `node --check` clean.