### PR TITLE
Operator recovery write path: progress, cancel, publish resume, JSON error receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,27 @@ bimo help doctor
 ones until interrupted. `bimo help COMMAND` (or `bimo COMMAND --help`) prints a
 command-specific synopsis; bare `bimo help` keeps the full usage.
 
+### Progress, cancel, and resume
+
+Long `organize` and `deploy` runs print the run ID to stderr as soon as it
+exists, then stream bounded progress there — run events as they land in the
+durable event log, plus a heartbeat every 30 seconds during quiet phases.
+With `--json`, stderr stays clean and stdout carries only the final receipt;
+failures then also print a single-line `{"ok":false,"error":{...}}` receipt on
+stdout while the human message stays on stderr.
+
+`cancel` sends SIGTERM to the deployment's running controller (or publisher)
+container on the target; the in-container controller cancels active work and
+finishes the run durably. `publish` resumes an interrupted pod publication
+from the durable `publication.ready` record — replaying an already completed
+publication returns its receipt with zero new side effects.
+
+```bash
+bimo cancel --deployment fleet-demo --host deploy@docker-host.example
+bimo publish --deployment pod-demo --host deploy@docker-host.example \
+  --github-secret-ref 'op://VAULT/ITEM/FIELD'
+```
+
 ### Deploy locally
 
 With Docker available, no target flags are required. On this Mac, for example,

--- a/src/bimo.mjs
+++ b/src/bimo.mjs
@@ -1532,7 +1532,6 @@ function interruptibleSleep(ms, signal) {
       resolve();
     };
     const timer = setTimeout(finish, ms);
-    timer.unref?.();
     signal?.addEventListener("abort", finish, { once: true });
   });
 }

--- a/src/bimo.mjs
+++ b/src/bimo.mjs
@@ -31,7 +31,7 @@ import {
 import { runOrganizerController } from "./organizer-controller.mjs";
 import { loadPodTemplate } from "./pod-contract.mjs";
 import { runEngineeringPod } from "./pod-controller.mjs";
-import { createPodRunStore, prunePodRuns } from "./pod-store.mjs";
+import { createPodRunStore, openPodRunStore, prunePodRuns } from "./pod-store.mjs";
 import { publishRun } from "./publish-run.mjs";
 import { loadWorkflow, runWorkflow } from "./workflow.mjs";
 
@@ -73,6 +73,8 @@ const DEPLOYMENT_LAYOUTS = {
 const RUN_LIST_LIMIT = 50;
 const RUN_SCAN_LIMIT = 1_000;
 const FOLLOW_POLL_MS = 2_000;
+const PROGRESS_HEARTBEAT_MS = 30_000;
+const PROGRESS_LINE_MAX = 320;
 const TAIL_CHUNK_BYTES = 64 * 1024 + 1;
 const DOCTOR_MIN_FREE_BLOCKS = 1_048_576;
 const RUN_STATES = new Set(["running", "completed", "failed", "cancelled"]);
@@ -832,12 +834,37 @@ async function deploy(template, options) {
   if (!task.trim() || Buffer.byteLength(task) > 64 * 1024) fail("task must contain 1 to 65536 bytes");
   if (!options["secret-ref"]) fail("--secret-ref is required");
 
-  const { remoteImage, transferTag } = await prepareImage(deploymentTarget, image);
+  const runId = `${new Date().toISOString().replace(/[-:.TZ]/g, "").slice(0, 14)}-${randomUUID().slice(0, 8)}`;
+  const progress = options.json ? null : new AbortController();
+  if (progress) process.stderr.write(`run: ${runId}\n`);
+  const heartbeat = progress ? startRunHeartbeat({ runId }) : null;
+  let follower = null;
+  let transferTag = null;
   try {
+    heartbeat?.setPhase("preparing image");
+    const prepared = await prepareImage(deploymentTarget, image);
+    const remoteImage = prepared.remoteImage;
+    transferTag = prepared.transferTag;
     const hostRoot = deploymentRootForTarget(deploymentTarget, options.deployment);
+    if (progress) {
+      heartbeat.setPhase("running controller");
+      const readChunk = async ({ runId: current, after, signal }) => {
+        const update = await targetExecute(deploymentTarget, stateReadArgs(hostRoot, remoteImage.imageId, [
+          "internal-tail", "--run", current, "--after", String(after),
+        ]), { timeoutMs: 30_000, maxOutputBytes: 256 * 1024, signal });
+        return parseTailUpdate(update.stdout);
+      };
+      follower = streamRunProgress({
+        readChunk,
+        runId,
+        signal: progress.signal,
+        onEvent: event => {
+          if (typeof event?.type === "string") heartbeat.setPhase(event.type);
+        },
+      }).catch(() => {});
+    }
     if (pod) {
       await prepareDeploymentState(deploymentTarget, remoteImage.imageId, hostRoot, "pod");
-      const runId = `${new Date().toISOString().replace(/[-:.TZ]/g, "").slice(0, 14)}-${randomUUID().slice(0, 8)}`;
       let openRouterKey = await resolveSecret(options["secret-ref"], options.account);
       const computeEnvelope = JSON.stringify({
         version: 1,
@@ -898,6 +925,7 @@ async function deploy(template, options) {
         token: githubToken,
       });
       githubToken = "";
+      heartbeat?.setPhase("publishing");
       const publisher = await targetExecute(deploymentTarget, [
         "docker", "run", "--rm", "-i",
         "--name", `bimo-${options.deployment}-publisher`,
@@ -939,6 +967,7 @@ async function deploy(template, options) {
         image: remoteImage.imageId,
         port,
         publicUrl: publicUrl.toString().replace(/\/$/, ""),
+        runId,
       });
       const controllerName = `bimo-${options.deployment}-controller`;
       const result = await targetExecute(deploymentTarget, [
@@ -969,6 +998,9 @@ async function deploy(template, options) {
       else process.stdout.write(`deployed ${response.template} as ${response.deployment}\nrun: ${response.runId}\nurl: ${response.url}\n`);
     }
   } finally {
+    progress?.abort();
+    if (follower) await follower;
+    heartbeat?.stop();
     await cleanupTransferredImage(deploymentTarget, transferTag);
   }
 }
@@ -995,11 +1027,36 @@ async function organizeRemote(options) {
   const catalog = await loadOrganizerCatalog();
   validateOrganizerInput({ prompt, agents, catalog });
 
-  const { remoteImage, transferTag } = await prepareImage(deploymentTarget, image, { retag: false });
+  const runId = `${new Date().toISOString().replace(/[-:.TZ]/g, "").slice(0, 14)}-${randomUUID().slice(0, 8)}`;
+  const progress = options.json ? null : new AbortController();
+  if (progress) process.stderr.write(`run: ${runId}\n`);
+  const heartbeat = progress ? startRunHeartbeat({ runId }) : null;
+  let follower = null;
+  let transferTag = null;
   try {
+    heartbeat?.setPhase("preparing image");
+    const prepared = await prepareImage(deploymentTarget, image, { retag: false });
+    const remoteImage = prepared.remoteImage;
+    transferTag = prepared.transferTag;
     const hostRoot = deploymentRootForTarget(deploymentTarget, options.deployment);
+    if (progress) {
+      heartbeat.setPhase("running controller");
+      const readChunk = async ({ runId: current, after, signal }) => {
+        const update = await targetExecute(deploymentTarget, stateReadArgs(hostRoot, remoteImage.imageId, [
+          "internal-tail", "--run", current, "--after", String(after),
+        ]), { timeoutMs: 30_000, maxOutputBytes: 256 * 1024, signal });
+        return parseTailUpdate(update.stdout);
+      };
+      follower = streamRunProgress({
+        readChunk,
+        runId,
+        signal: progress.signal,
+        onEvent: event => {
+          if (typeof event?.type === "string") heartbeat.setPhase(event.type);
+        },
+      }).catch(() => {});
+    }
     await prepareDeploymentState(deploymentTarget, remoteImage.imageId, hostRoot, "organizer");
-    const runId = `${new Date().toISOString().replace(/[-:.TZ]/g, "").slice(0, 14)}-${randomUUID().slice(0, 8)}`;
     let openRouterKey = await resolveSecret(options["secret-ref"], options.account);
     const envelope = JSON.stringify({
       version: 1,
@@ -1051,6 +1108,9 @@ async function organizeRemote(options) {
       "",
     ].join("\n"));
   } finally {
+    progress?.abort();
+    if (follower) await follower;
+    heartbeat?.stop();
     await cleanupTransferredImage(deploymentTarget, transferTag);
   }
 }
@@ -1192,7 +1252,7 @@ async function internalRun(options) {
   const raw = await readStdin(128 * 1024);
   let envelope;
   try { envelope = JSON.parse(raw); } catch { fail("invalid controller envelope"); }
-  const expected = ["version", "template", "templateDigest", "deployment", "task", "key", "model", "image", "port", "publicUrl"].sort();
+  const expected = ["version", "template", "templateDigest", "deployment", "task", "key", "model", "image", "port", "publicUrl", "runId"].sort();
   if (!envelope || typeof envelope !== "object" || Array.isArray(envelope)
       || Object.keys(envelope).sort().some((key, index) => key !== expected[index])
       || Object.keys(envelope).length !== expected.length) {
@@ -1200,7 +1260,8 @@ async function internalRun(options) {
   }
   if (envelope.version !== 1 || !NAME.test(envelope.deployment ?? "") || !NAME.test(envelope.template ?? "")
       || !controllerHostRootIsValid(options["host-root"], envelope.deployment, options["local-home"])
-      || !TEMPLATE_DIGEST.test(envelope.templateDigest ?? "") || !SHA256.test(envelope.image ?? "")) {
+      || !TEMPLATE_DIGEST.test(envelope.templateDigest ?? "") || !SHA256.test(envelope.image ?? "")
+      || !RUN_ID.test(envelope.runId ?? "")) {
     fail("controller envelope is invalid");
   }
   const loaded = await loadWorkflow(envelope.template, { templateRoot });
@@ -1216,7 +1277,7 @@ async function internalRun(options) {
     publicUrl: envelope.publicUrl,
   });
   envelope.key = null;
-  const result = await runController({ loaded, envelope, runtime });
+  const result = await runController({ loaded, envelope, runtime, runId: envelope.runId });
   process.stdout.write(`${JSON.stringify({ ...result, template: envelope.template, deployment: envelope.deployment })}\n`);
 }
 
@@ -1419,6 +1480,132 @@ async function internalPublish(options) {
     deadlineAt: Date.now() + PUBLISH_TIMEOUT_MS,
   }, { gitRunner: runPublisherGit });
   process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+async function internalPublishResume(options) {
+  exactOptions(options, ["state-root"]);
+  const stateRoot = internalStateRoot(options);
+  const envelope = await readJsonEnvelope(16 * 1024, ["version", "runId", "token"], "publisher resume");
+  if (envelope.version !== 1 || !RUN_ID.test(envelope.runId ?? "") || !GITHUB_TOKEN.test(envelope.token ?? "")) {
+    fail("publisher resume envelope is invalid");
+  }
+  let runId = envelope.runId;
+  if (runId === "latest") {
+    runId = (await readFile(path.join(stateRoot, "latest"), "utf8").catch(() => "")).trim();
+    if (!RUN_ID.test(runId)) fail("no latest run is recorded");
+  }
+  const store = await openPodRunStore({ stateRoot, runId });
+  const ready = store.events.filter(event => event.type === "publication.ready");
+  if (ready.length !== 1) fail("run has no unique publication.ready record");
+  const { repository, targetBranch, baseSha, candidateSha, headBranch } = ready[0];
+  if (repository !== POD_REPOSITORY || targetBranch !== POD_TARGET_BRANCH
+      || !GIT_SHA.test(baseSha ?? "") || !GIT_SHA.test(candidateSha ?? "")
+      || headBranch !== `bimo/${runId}`) {
+    fail("publication.ready record is invalid");
+  }
+  const token = envelope.token;
+  envelope.token = null;
+  const result = await publishRun({
+    runId,
+    stateRoot,
+    sourceGitDir: "/source/repository.git",
+    repository,
+    targetBranch,
+    baseSha,
+    candidateSha,
+    headBranch,
+    token,
+    deadlineAt: Date.now() + PUBLISH_TIMEOUT_MS,
+  }, { gitRunner: runPublisherGit });
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+function interruptibleSleep(ms, signal) {
+  return new Promise(resolve => {
+    if (signal?.aborted) {
+      resolve();
+      return;
+    }
+    const finish = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", finish);
+      resolve();
+    };
+    const timer = setTimeout(finish, ms);
+    timer.unref?.();
+    signal?.addEventListener("abort", finish, { once: true });
+  });
+}
+
+export function startRunHeartbeat({
+  runId,
+  intervalMs = PROGRESS_HEARTBEAT_MS,
+  now = () => Date.now(),
+  write = line => process.stderr.write(line),
+} = {}) {
+  if (!RUN_ID.test(runId ?? "")) fail("run ID is invalid");
+  if (!Number.isSafeInteger(intervalMs) || intervalMs < 1) fail("heartbeat interval is invalid");
+  const startedAt = now();
+  let phase = "starting";
+  const timer = setInterval(() => {
+    const elapsed = Math.max(0, Math.round((now() - startedAt) / 1_000));
+    write(`run ${runId}: still working (${phase}, ${elapsed}s elapsed)\n`);
+  }, intervalMs);
+  timer.unref?.();
+  return Object.freeze({
+    setPhase(next) {
+      if (typeof next === "string" && next.length >= 1 && next.length <= 64
+          && !/[\u0000-\u001f\u007f]/u.test(next)) {
+        phase = next;
+      }
+    },
+    stop() {
+      clearInterval(timer);
+    },
+  });
+}
+
+export async function streamRunProgress({
+  readChunk,
+  runId,
+  signal,
+  pollMs = FOLLOW_POLL_MS,
+  write = line => process.stderr.write(line),
+  onEvent,
+} = {}) {
+  if (typeof readChunk !== "function") fail("progress reader is invalid");
+  if (!RUN_ID.test(runId ?? "")) fail("run ID is invalid");
+  if (!Number.isSafeInteger(pollMs) || pollMs < 1) fail("progress poll interval is invalid");
+  let offset = 0;
+  let resolved = runId;
+  while (!signal?.aborted) {
+    try {
+      const update = await readChunk({ runId: resolved, after: offset, signal });
+      if (!isPlainObject(update) || !RUN_ID.test(update.runId ?? "")
+          || !Number.isSafeInteger(update.offset) || typeof update.chunk !== "string") {
+        fail("progress update is invalid");
+      }
+      resolved = update.runId;
+      offset = update.offset;
+      if (update.chunk) {
+        for (const line of update.chunk.trimEnd().split("\n")) {
+          write(`${`run ${runId}: ${formatFollowEvent(line)}`.slice(0, PROGRESS_LINE_MAX)}\n`);
+          if (onEvent) {
+            try {
+              onEvent(JSON.parse(line));
+            } catch {
+              // Progress rendering must not fail the run.
+            }
+          }
+        }
+      }
+    } catch (error) {
+      if (signal?.aborted) break;
+      if (error instanceof Error && error.message === "progress update is invalid") throw error;
+      // The run directory may not exist yet; keep polling.
+    }
+    await interruptibleSleep(pollMs, signal);
+  }
 }
 
 async function remoteLogs(options) {
@@ -1766,6 +1953,120 @@ async function remoteStatus(options) {
   process.stdout.write(result.stdout);
 }
 
+async function remoteCancel(options) {
+  exactOptions(options, ["deployment", "target", "proxmox", "host", "vmid", "run", "image", "json"]);
+  if (!NAME.test(options.deployment ?? "")) fail("--deployment is invalid");
+  const runId = options.run ?? null;
+  if (runId !== null && !RUN_ID.test(runId)) fail("--run is invalid");
+  const deploymentTarget = resolveDeploymentTarget(options);
+  if (deploymentTarget.kind === "local") await requireLocalDocker();
+  const image = options.image ?? DEFAULT_IMAGE;
+  if (!IMAGE.test(image)) fail("--image is invalid");
+  const hostRoot = deploymentRootForTarget(deploymentTarget, options.deployment);
+  if (runId !== null) {
+    const statusResult = await targetExecute(deploymentTarget, stateReadArgs(hostRoot, image, [
+      "internal-status",
+      "--deployment", options.deployment,
+      "--run", runId,
+      "--json",
+    ]), { maxOutputBytes: 64 * 1024 });
+    const status = parseLastJson(statusResult.stdout, "run status");
+    if (!isPlainObject(status) || typeof status.state !== "string") fail("run status is invalid");
+    if (status.state !== "running") fail(`run ${runId} is ${status.state}; nothing to cancel`);
+  }
+  const signalled = [];
+  for (const name of [
+    `bimo-${options.deployment}-controller`,
+    `bimo-${options.deployment}-publisher`,
+  ]) {
+    const sent = await targetExecute(deploymentTarget, [
+      "docker", "kill", "--signal", "SIGTERM", name,
+    ], { timeoutMs: 30_000, maxOutputBytes: 16 * 1024 }).then(() => true, () => false);
+    if (sent) signalled.push(name);
+  }
+  if (signalled.length === 0) {
+    fail(`no running controller or publisher for deployment ${options.deployment}`);
+  }
+  const receipt = { deployment: options.deployment, run: runId, signalled };
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(receipt)}\n`);
+    return;
+  }
+  for (const name of signalled) {
+    process.stdout.write(`sent SIGTERM to ${name}; the run will finish as failed or cancelled\n`);
+  }
+}
+
+function validateResumedPublication(value) {
+  exactObject(value, [
+    "status", "runId", "repository", "targetBranch", "baseSha", "candidateSha",
+    "headBranch", "publication",
+  ], "pod publisher");
+  if (value.status !== "completed" || !RUN_ID.test(value.runId ?? "")
+      || value.repository !== POD_REPOSITORY || value.targetBranch !== POD_TARGET_BRANCH
+      || !GIT_SHA.test(value.baseSha ?? "") || !GIT_SHA.test(value.candidateSha ?? "")
+      || value.headBranch !== `bimo/${value.runId}`) {
+    fail("pod publisher returned an invalid completion receipt");
+  }
+  const publication = value.publication;
+  if (!isPlainObject(publication)
+      || Object.keys(publication).some(key => ![
+        "baseSha", "created", "draft", "headBranch", "headSha", "number", "reconciled",
+        "targetBranch", "url",
+      ].includes(key))
+      || !Number.isSafeInteger(publication.number) || publication.number < 1
+      || publication.draft !== true || typeof publication.created !== "boolean"
+      || publication.baseSha !== value.baseSha || publication.headSha !== value.candidateSha
+      || publication.headBranch !== value.headBranch || publication.targetBranch !== POD_TARGET_BRANCH
+      || !new RegExp(`^https://github\\.com/zaycruz/bimo/pull/${publication.number}$`).test(publication.url ?? "")) {
+    fail("pod publisher returned an invalid draft pull request receipt");
+  }
+  return value;
+}
+
+async function remotePublish(options) {
+  exactOptions(options, [
+    "deployment", "target", "proxmox", "host", "vmid", "run",
+    "github-secret-ref", "account", "image", "json",
+  ]);
+  if (!NAME.test(options.deployment ?? "")) fail("--deployment is invalid");
+  const runId = options.run ?? "latest";
+  if (runId !== "latest" && !RUN_ID.test(runId)) fail("--run is invalid");
+  if (!options["github-secret-ref"]) fail("--github-secret-ref is required");
+  const deploymentTarget = resolveDeploymentTarget(options);
+  if (deploymentTarget.kind === "local") await requireLocalDocker();
+  const image = options.image ?? DEFAULT_IMAGE;
+  if (!IMAGE.test(image)) fail("--image is invalid");
+  const hostRoot = deploymentRootForTarget(deploymentTarget, options.deployment);
+  let githubToken = await resolveGitHubSecret(options["github-secret-ref"], options.account);
+  const envelope = JSON.stringify({ version: 1, runId, token: githubToken });
+  githubToken = "";
+  const publisher = await targetExecute(deploymentTarget, [
+    "docker", "run", "--rm", "-i",
+    "--name", `bimo-${options.deployment}-publisher`,
+    "--user", "0:0",
+    "--read-only",
+    "--cap-drop", "ALL",
+    "--security-opt", "no-new-privileges",
+    "--pids-limit", "128",
+    "--memory", "512m",
+    "--cpus", "0.5",
+    "--tmpfs", "/tmp:rw,nosuid,nodev,noexec,size=32m",
+    "--tmpfs", "/run/bimo-publish:rw,nosuid,nodev,noexec,size=16m,mode=0700",
+    "--volume", `${hostRoot}/runs:/state:rw`,
+    "--volume", `${hostRoot}/source:/source:rw`,
+    image,
+    "internal-publish-resume",
+  ], {
+    input: envelope,
+    timeoutMs: PUBLISH_TIMEOUT_MS + 60_000,
+    maxOutputBytes: 512 * 1024,
+  });
+  const response = validateResumedPublication(parseLastJson(publisher.stdout, "pod publisher"));
+  if (options.json) process.stdout.write(`${JSON.stringify(response)}\n`);
+  else process.stdout.write(`published ${response.runId}\nPR: ${response.publication.url} (draft)\n`);
+}
+
 function formatFollowEvent(line) {
   let event;
   try {
@@ -2050,6 +2351,8 @@ const COMMAND_HELP = {
   status: "bimo status --deployment NAME [target flags] [--run ID] [--json]\n  Print the latest run state and last event for a deployment.",
   logs: "bimo logs --deployment NAME [target flags] [--run ID] [--json] [--follow]\n  Print a run log; --follow streams new events until interrupted.",
   doctor: "bimo doctor [--deployment NAME] [target flags] [--secret-ref op://VAULT/ITEM/FIELD] [--json]\n  Run deployment preflight checks and report pass, fail, or skip per check.",
+  cancel: "bimo cancel --deployment NAME [target flags] [--run ID] [--json]\n  Send SIGTERM to the deployment's running controller or publisher container on the target; the in-container controller cancels active work and finishes the run durably.",
+  publish: "bimo publish --deployment NAME --github-secret-ref op://VAULT/ITEM/FIELD [target flags] [--run ID] [--json]\n  Resume an interrupted pod publication from the durable publication.ready record; an already completed publication replays its receipt with zero new side effects.",
 };
 
 function usage() {
@@ -2065,11 +2368,13 @@ function usage() {
   bimo runs --deployment NAME [--target local | --target ssh --host HOST | --target proxmox-lxc --proxmox HOST --vmid ID] [--json]
   bimo status --deployment NAME [--target local | --target ssh --host HOST | --target proxmox-lxc --proxmox HOST --vmid ID] [--run ID] [--json]
   bimo doctor [--deployment NAME] [--target local | --target ssh --host HOST | --target proxmox-lxc --proxmox HOST --vmid ID] [--secret-ref op://VAULT/ITEM/FIELD] [--json]
+  bimo cancel --deployment NAME [--target local | --target ssh --host HOST | --target proxmox-lxc --proxmox HOST --vmid ID] [--run ID] [--json]
+  bimo publish --deployment NAME [--target local | --target ssh --host HOST | --target proxmox-lxc --proxmox HOST --vmid ID] --github-secret-ref op://VAULT/ITEM/FIELD [--run ID] [--json]
   bimo help [COMMAND]
 `;
 }
 
-export async function main(argv = process.argv.slice(2)) {
+async function runCommand(argv) {
   let [command, ...rest] = argv;
   if (command === "-p" || command === "--prompt") {
     command = "organize";
@@ -2168,6 +2473,18 @@ export async function main(argv = process.argv.slice(2)) {
     await doctor(options);
     return;
   }
+  if (command === "cancel") {
+    const { positional, options } = parseOptions(rest, { booleans: ["json"] });
+    if (positional.length) fail("cancel accepts no positional arguments");
+    await remoteCancel(options);
+    return;
+  }
+  if (command === "publish") {
+    const { positional, options } = parseOptions(rest, { booleans: ["json"] });
+    if (positional.length) fail("publish accepts no positional arguments");
+    await remotePublish(options);
+    return;
+  }
   if (command === "internal-run") {
     const { positional, options } = parseOptions(rest);
     if (positional.length) fail("internal-run accepts no positional arguments");
@@ -2198,6 +2515,12 @@ export async function main(argv = process.argv.slice(2)) {
     await internalPublish(options);
     return;
   }
+  if (command === "internal-publish-resume") {
+    const { positional, options } = parseOptions(rest);
+    if (positional.length) fail("internal-publish-resume accepts no positional arguments");
+    await internalPublishResume(options);
+    return;
+  }
   if (command === "internal-logs") {
     await internalLogs(rest);
     return;
@@ -2215,4 +2538,26 @@ export async function main(argv = process.argv.slice(2)) {
     return;
   }
   fail(`unknown command: ${command}`);
+}
+
+function errorReceiptMessage(error) {
+  return (error instanceof Error && typeof error.message === "string" ? error.message : String(error))
+    .replace(/[\u0000-\u001f\u007f]+/gu, " ")
+    .trim()
+    .slice(0, 500) || "command failed";
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  try {
+    await runCommand(argv);
+  } catch (error) {
+    if (argv.includes("--json")) {
+      const command = argv[0] === "-p" || argv[0] === "--prompt" ? "organize" : argv[0] ?? null;
+      process.stdout.write(`${JSON.stringify({
+        ok: false,
+        error: { command, message: errorReceiptMessage(error) },
+      })}\n`);
+    }
+    throw error;
+  }
 }

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -9,8 +9,9 @@ import { promisify } from "node:util";
 import path from "node:path";
 import test from "node:test";
 
-import { runController, runPodController } from "../src/bimo.mjs";
+import { runController, runPodController, startRunHeartbeat, streamRunProgress } from "../src/bimo.mjs";
 import { loadPodTemplate } from "../src/pod-contract.mjs";
+import { createPodRunStore } from "../src/pod-store.mjs";
 import { loadWorkflow } from "../src/workflow.mjs";
 
 const execute = promisify(execFile);
@@ -119,6 +120,14 @@ if (args[0] === "context" && args[1] === "inspect") process.stdout.write(process
 else if (args[0] === "version") process.stdout.write("linux/arm64\\n");
 else if (args[0] === "image" && args[1] === "inspect") process.stdout.write(process.env.BIMO_TEST_LOCAL_INSPECT + "\\n");
 else if (args[0] === "save") process.stdout.write("fake-image-archive");
+else if (args[0] === "kill") {
+  const name = args[args.length - 1];
+  if ((process.env.BIMO_TEST_KILL ?? "").split(",").includes(name)) process.stdout.write(name + "\\n");
+  else {
+    process.stderr.write("Error: No such container: " + name + "\\n");
+    process.exitCode = 1;
+  }
+}
 else if (args[0] === "run") {
   const internalCommand = args.find(value => value === "internal-prepare" || value === "internal-run");
   if (internalCommand === "internal-prepare") process.stdout.write("prepared\\n");
@@ -133,11 +142,12 @@ else if (args[0] === "run") {
         fields: Object.keys(envelope).sort(),
         templateDigest: envelope.templateDigest,
         image: envelope.image,
+        runId: envelope.runId,
       });
       process.stdout.write(JSON.stringify({
         template: envelope.template,
         deployment: envelope.deployment,
-        runId: "local-test-run",
+        runId: envelope.runId,
         url: envelope.publicUrl,
       }) + "\\n");
     });
@@ -155,6 +165,15 @@ const log = value => fs.appendFileSync(process.env.BIMO_TEST_LOG, JSON.stringify
 log({ tool: "ssh", args, command });
 if (runtimeCommand[0] === "true" || runtimeCommand[0] === "test") {
   process.exit(0);
+} else if (runtimeCommand[0] === "docker" && runtimeCommand[1] === "kill") {
+  const name = runtimeCommand[runtimeCommand.length - 1];
+  log({ tool: "docker-kill", name });
+  if ((process.env.BIMO_TEST_KILL ?? "").split(",").includes(name)) {
+    process.stdout.write(name + "\\n");
+  } else {
+    process.stderr.write("Error: No such container: " + name + "\\n");
+    process.exitCode = 1;
+  }
 } else if (runtimeCommand[0] === "df") {
   process.stdout.write("Filesystem 1024-blocks Used Available Capacity Mounted on\\n/dev/disk1 488245288 10000000 470000000 3% /\\n");
 } else if (runtimeCommand[0] === "pct") {
@@ -189,7 +208,7 @@ if (runtimeCommand[0] === "true" || runtimeCommand[0] === "test") {
       image: envelope.image,
     });
     const internalCommand = command.find(value => value === "internal-pod-run"
-      || value === "internal-publish" || value === "internal-organize");
+      || value === "internal-publish" || value === "internal-publish-resume" || value === "internal-organize");
     if (process.env.BIMO_TEST_CONTROLLER === "conflict") {
       process.stderr.write("Conflict: controller name is already in use\\n");
       process.exitCode = 125;
@@ -239,6 +258,32 @@ if (runtimeCommand[0] === "true" || runtimeCommand[0] === "test") {
           baseSha: envelope.baseSha,
         },
       }) + "\\n");
+    } else if (process.env.BIMO_TEST_CONTROLLER === "publish-resume-success"
+      && internalCommand === "internal-publish-resume") {
+      log({
+        tool: "publish-resume-envelope",
+        fields: Object.keys(envelope).sort(),
+        runId: envelope.runId,
+      });
+      process.stdout.write(JSON.stringify({
+        status: "completed",
+        runId: envelope.runId,
+        repository: "https://github.com/zaycruz/bimo.git",
+        targetBranch: "main",
+        baseSha: process.env.BIMO_TEST_POD_BASE,
+        candidateSha: process.env.BIMO_TEST_POD_CANDIDATE,
+        headBranch: "bimo/" + envelope.runId,
+        publication: {
+          number: 43,
+          url: "https://github.com/zaycruz/bimo/pull/43",
+          draft: true,
+          created: false,
+          headBranch: "bimo/" + envelope.runId,
+          headSha: process.env.BIMO_TEST_POD_CANDIDATE,
+          targetBranch: "main",
+          baseSha: process.env.BIMO_TEST_POD_BASE,
+        },
+      }) + "\\n");
     } else if (process.env.BIMO_TEST_CONTROLLER === "organize-success"
       && internalCommand === "internal-organize") {
       const template = process.env.BIMO_TEST_ORGANIZER_TEMPLATE;
@@ -271,7 +316,7 @@ if (runtimeCommand[0] === "true" || runtimeCommand[0] === "test") {
       process.stdout.write(JSON.stringify({
         template: envelope.template,
         deployment: envelope.deployment,
-        runId: "test-run",
+        runId: envelope.runId ?? "test-run",
         url: envelope.publicUrl,
       }) + "\\n");
     }
@@ -312,6 +357,7 @@ else {
       }),
       BIMO_TEST_REMOTE_PLATFORM: remotePlatform,
       BIMO_TEST_CONTROLLER: controller,
+      BIMO_TEST_POD_BASE: POD_BASE_SHA,
       BIMO_TEST_POD_CANDIDATE: POD_CANDIDATE_SHA,
       BIMO_TEST_ORGANIZER_TEMPLATE: "react-app",
       BIMO_TEST_ORGANIZER_DIGEST: (await loadWorkflow("react-app", {
@@ -516,12 +562,11 @@ test("deploy defaults to local Docker without SSH or image transfer", async t =>
   const result = await invoke(args, { env: tools.env });
 
   assert.equal(result.code, 0, result.stderr);
-  assert.deepEqual(JSON.parse(result.stdout), {
-    template: "react-app",
-    deployment: "fleet-demo",
-    runId: "local-test-run",
-    url: "http://example.invalid:8080",
-  });
+  const response = JSON.parse(result.stdout);
+  assert.equal(response.template, "react-app");
+  assert.equal(response.deployment, "fleet-demo");
+  assert.match(response.runId, /^\d{14}-[0-9a-f]{8}$/);
+  assert.equal(response.url, "http://example.invalid:8080");
 
   const entries = await readCommandLog(tools.logFile);
   assert.equal(entries.some(entry => entry.tool === "ssh"), false);
@@ -543,6 +588,7 @@ test("deploy defaults to local Docker without SSH or image transfer", async t =>
   assert.equal(controller[controller.indexOf("internal-run") - 1], LOCAL_IMAGE_ID);
   const envelope = entries.find(entry => entry.tool === "local-controller-envelope");
   assert.equal(envelope.image, LOCAL_IMAGE_ID);
+  assert.equal(envelope.runId, response.runId);
 });
 
 test("explicit SSH target builds for the target daemon architecture", async t => {
@@ -871,6 +917,7 @@ test("internal-run rejects an invalid or mismatched template digest before Docke
     image: LOCAL_IMAGE_ID,
     port: 8080,
     publicUrl: "http://example.invalid:8080",
+    runId: "workflow-run-1",
   };
   const mismatch = await invoke([
     "internal-run",
@@ -1591,4 +1638,310 @@ test("runs, status, logs --follow, and doctor reject invalid options before Dock
     assert.match(result.stderr, pattern);
   }
   assert.deepEqual(await readCommandLog(tools.logFile), []);
+});
+
+test("failures print a structured JSON receipt on stdout when --json is requested", async () => {
+  const failure = await invoke(["deploy", "react-app", "--deployment", "Fleet_Demo", "--json"]);
+  assert.equal(failure.code, 1);
+  const receipt = JSON.parse(failure.stdout);
+  assert.equal(receipt.ok, false);
+  assert.equal(receipt.error.command, "deploy");
+  assert.match(receipt.error.message, /--deployment must use lowercase letters/);
+  assert.match(failure.stderr, /^bimo: --deployment must use lowercase letters/);
+
+  const plain = await invoke(["deploy", "react-app", "--deployment", "Fleet_Demo"]);
+  assert.equal(plain.code, 1);
+  assert.equal(plain.stdout, "");
+  assert.match(plain.stderr, /^bimo: --deployment must use lowercase letters/);
+});
+
+test("run heartbeat emits bounded phase lines until stopped", async () => {
+  const lines = [];
+  const heartbeat = startRunHeartbeat({
+    runId: "run-1",
+    intervalMs: 5,
+    write: line => lines.push(line),
+  });
+  heartbeat.setPhase("preparing image");
+  heartbeat.setPhase("unsafephase");
+  await new Promise(resolve => setTimeout(resolve, 30));
+  heartbeat.stop();
+  const ticks = lines.length;
+  await new Promise(resolve => setTimeout(resolve, 15));
+  assert.equal(lines.length, ticks);
+  assert.ok(ticks >= 1);
+  for (const line of lines) {
+    assert.match(line, /^run run-1: still working \(preparing image, \d+s elapsed\)\n$/);
+  }
+});
+
+test("run progress streams bounded event lines and tolerates a missing run", async () => {
+  const runId = "run-1";
+  const eventA = JSON.stringify({
+    version: 1, sequence: 1, timestamp: "2024-01-01T00:00:00.000Z", runId, type: "run.started",
+  });
+  const eventB = JSON.stringify({
+    version: 1, sequence: 2, timestamp: "2024-01-01T00:01:00.000Z", runId,
+    type: "gate.finished", status: "passed",
+  });
+  const chunk = `${eventA}\n${eventB}\n`;
+  const offset = Buffer.byteLength(chunk);
+  const reads = [];
+  const phases = [];
+  const lines = [];
+  const abort = new AbortController();
+  let calls = 0;
+  const readChunk = async ({ runId: current, after }) => {
+    calls += 1;
+    reads.push(after);
+    if (calls === 1) throw new Error("unknown run: run-1");
+    if (calls >= 4) abort.abort();
+    return { runId: current, offset, size: offset, chunk: calls === 2 ? chunk : "" };
+  };
+  await streamRunProgress({
+    readChunk,
+    runId,
+    signal: abort.signal,
+    pollMs: 1,
+    write: line => lines.push(line),
+    onEvent: event => phases.push(event.type),
+  });
+  assert.deepEqual(reads.slice(0, 3), [0, 0, offset]);
+  assert.equal(lines.length, 2);
+  assert.equal(lines[0], "run run-1: 2024-01-01T00:00:00.000Z run.started\n");
+  assert.equal(lines[1], "run run-1: 2024-01-01T00:01:00.000Z gate.finished passed\n");
+  assert.ok(lines.every(line => line.length <= 321));
+  assert.deepEqual(phases, ["run.started", "gate.finished"]);
+});
+
+test("organize prints the run ID on stderr before long work in human mode", async t => {
+  const tools = await fakeDeployTools(t, { controller: "organize-success" });
+  const args = organizeArgs("Build a small status page.", 1).filter(value => value !== "--json");
+  const result = await invoke(args, { env: tools.env });
+  assert.equal(result.code, 0, result.stderr);
+  const stderrLines = result.stderr.trimEnd().split("\n");
+  assert.match(stderrLines[0], /^run: \d{14}-[0-9a-f]{8}$/);
+  assert.ok(stderrLines.every(line => line.length <= 320));
+  assert.ok(result.stdout.includes(`run: ${stderrLines[0].slice(5)}`));
+});
+
+test("cancel and publish reject invalid options before Docker", async t => {
+  const tools = await fakeDeployTools(t);
+  for (const [args, pattern] of [
+    [["cancel"], /--deployment is invalid/],
+    [["cancel", "--deployment", "fleet-demo", "--run", "$(id)"], /--run is invalid/],
+    [["cancel", "--deployment", "fleet-demo", "--unknown", "x"], /unknown option: --unknown/],
+    [["publish", "--deployment", "Fleet_Demo", "--github-secret-ref", "op://a/b/c"], /--deployment is invalid/],
+    [["publish", "--deployment", "fleet-demo", "--run", "bad;id", "--github-secret-ref", "op://a/b/c"], /--run is invalid/],
+    [["publish", "--deployment", "fleet-demo"], /--github-secret-ref is required/],
+  ]) {
+    const result = await invoke(args, { env: tools.env });
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, pattern);
+  }
+  assert.deepEqual(await readCommandLog(tools.logFile), []);
+});
+
+test("cancel sends SIGTERM to the running controller or publisher on the target", async t => {
+  const tools = await fakeDeployTools(t);
+  const cancelArgs = [
+    "cancel", "--deployment", "fleet-demo", "--host", "example.invalid",
+    "--image", "bimo-workflow:test", "--json",
+  ];
+  const result = await invoke(cancelArgs, {
+    env: { ...tools.env, BIMO_TEST_KILL: "bimo-fleet-demo-controller" },
+  });
+  assert.equal(result.code, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    deployment: "fleet-demo",
+    run: null,
+    signalled: ["bimo-fleet-demo-controller"],
+  });
+  const kills = (await readCommandLog(tools.logFile))
+    .filter(entry => entry.tool === "docker-kill")
+    .map(entry => entry.name);
+  assert.deepEqual(kills, ["bimo-fleet-demo-controller", "bimo-fleet-demo-publisher"]);
+  const commands = (await readCommandLog(tools.logFile))
+    .filter(entry => entry.tool === "ssh")
+    .map(entry => entry.command);
+  const kill = commands.find(command => command[1] === "kill");
+  assert.deepEqual(kill.slice(0, 4), ["docker", "kill", "--signal", "SIGTERM"]);
+
+  const idle = await invoke(cancelArgs, { env: tools.env });
+  assert.equal(idle.code, 1);
+  assert.match(idle.stderr, /no running controller or publisher for deployment fleet-demo/);
+  const receipt = JSON.parse(idle.stdout);
+  assert.equal(receipt.ok, false);
+  assert.equal(receipt.error.command, "cancel");
+});
+
+test("cancel --run refuses a terminal run and signals a live one", async t => {
+  const tools = await fakeDeployTools(t);
+  const statusPayload = state => `${JSON.stringify({
+    deployment: "fleet-demo", runId: "run-1", state, phase: null,
+    startedAt: "2024-01-01T00:00:00.000Z", finishedAt: null, attempts: 1, lastEvent: null,
+  })}\n`;
+  const cancelArgs = [
+    "cancel", "--deployment", "fleet-demo", "--host", "example.invalid",
+    "--run", "run-1", "--image", "bimo-workflow:test", "--json",
+  ];
+  const terminal = await invoke(cancelArgs, {
+    env: { ...tools.env, BIMO_TEST_STATUS_OUTPUT: statusPayload("completed") },
+  });
+  assert.equal(terminal.code, 1);
+  assert.match(terminal.stderr, /run run-1 is completed; nothing to cancel/);
+  assert.equal((await readCommandLog(tools.logFile)).some(entry => entry.tool === "docker-kill"), false);
+
+  const live = await invoke(cancelArgs, {
+    env: {
+      ...tools.env,
+      BIMO_TEST_STATUS_OUTPUT: statusPayload("running"),
+      BIMO_TEST_KILL: "bimo-fleet-demo-publisher",
+    },
+  });
+  assert.equal(live.code, 0, live.stderr);
+  assert.deepEqual(JSON.parse(live.stdout), {
+    deployment: "fleet-demo",
+    run: "run-1",
+    signalled: ["bimo-fleet-demo-publisher"],
+  });
+});
+
+test("publish resumes an idempotent publication through the isolated publisher container", async t => {
+  const tools = await fakeDeployTools(t, { controller: "publish-resume-success" });
+  const runId = "20240101000000-abcd1234";
+  const result = await invoke([
+    "publish", "--deployment", "pod-demo", "--run", runId,
+    "--host", "example.invalid",
+    "--github-secret-ref", "op://Test/Bimo publisher/github",
+    "--image", "bimo-workflow:test",
+    "--json",
+  ], { env: tools.env });
+  assert.equal(result.code, 0, result.stderr);
+  const response = JSON.parse(result.stdout);
+  assert.equal(response.status, "completed");
+  assert.equal(response.runId, runId);
+  assert.equal(response.headBranch, `bimo/${runId}`);
+  assert.equal(response.publication.url, "https://github.com/zaycruz/bimo/pull/43");
+  assert.equal(response.publication.draft, true);
+
+  const entries = await readCommandLog(tools.logFile);
+  const remoteCommands = entries.filter(entry => entry.tool === "ssh").map(entry => entry.command);
+  const publisher = remoteCommands.find(command => command.includes("internal-publish-resume"));
+  assert.ok(publisher, "resume publisher was not launched");
+  assert.equal(publisher[publisher.indexOf("--name") + 1], "bimo-pod-demo-publisher");
+  const hostRoot = "/var/lib/bimo/deployments/pod-demo";
+  assert.ok(publisher.includes(`${hostRoot}/runs:/state:rw`));
+  assert.ok(publisher.includes(`${hostRoot}/source:/source:rw`));
+  assert.equal(publisher.some(value => value.includes("docker.sock")), false);
+  assert.equal(publisher.some(value => value.includes("worktrees") || value.includes("snapshots")), false);
+
+  const envelope = entries.find(entry => entry.tool === "publish-resume-envelope");
+  assert.deepEqual(envelope.fields, ["runId", "token", "version"]);
+  assert.equal(envelope.runId, runId);
+  assert.equal(JSON.stringify(entries).includes(`github_pat_${"g".repeat(64)}`), false);
+});
+
+async function fakePublicationStore(t, { completed = false, interrupted = false, ready = true } = {}) {
+  const directory = await mkdtemp(path.join(tmpdir(), "bimo-resume-test-"));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  const runId = "20240101000000-abcd1234";
+  const publication = {
+    number: 46,
+    url: "https://github.com/zaycruz/bimo/pull/46",
+    headBranch: `bimo/${runId}`,
+    headSha: POD_CANDIDATE_SHA,
+    targetBranch: "main",
+    baseSha: POD_BASE_SHA,
+    draft: true,
+    created: true,
+  };
+  const binding = {
+    repository: "https://github.com/zaycruz/bimo.git",
+    targetBranch: "main",
+    baseSha: POD_BASE_SHA,
+    candidateSha: POD_CANDIDATE_SHA,
+    headBranch: `bimo/${runId}`,
+  };
+  const store = await createPodRunStore({
+    stateRoot: directory,
+    runId,
+    assignment: { task: "Build the bounded change." },
+  });
+  if (ready) await store.appendEvent("publication.ready", binding);
+  if (completed || interrupted) {
+    await store.appendEvent("publication.finished", { ...binding, publication });
+  }
+  if (completed) await store.finish("completed", { phase: "published", ...binding, publication });
+  return { directory, runId, publication };
+}
+
+function resumeEnvelope(runId) {
+  return JSON.stringify({ version: 1, runId, token: `github_pat_${"g".repeat(64)}` });
+}
+
+test("internal-publish-resume replays a completed publication with zero new side effects", async t => {
+  const { directory, runId, publication } = await fakePublicationStore(t, { completed: true });
+  const result = await invoke(["internal-publish-resume", "--state-root", directory], {
+    input: resumeEnvelope(runId),
+  });
+  assert.equal(result.code, 0, result.stderr);
+  const receipt = JSON.parse(result.stdout);
+  assert.equal(receipt.status, "completed");
+  assert.equal(receipt.runId, runId);
+  assert.equal(receipt.publication.number, publication.number);
+  assert.equal(receipt.publication.url, publication.url);
+  const events = (await readFile(path.join(directory, runId, "events.jsonl"), "utf8"))
+    .trim().split("\n");
+  assert.equal(events.length, 3);
+});
+
+test("internal-publish-resume finishes an interrupted publication without Git or API work", async t => {
+  const { directory, runId, publication } = await fakePublicationStore(t, { interrupted: true });
+  const result = await invoke(["internal-publish-resume", "--state-root", directory], {
+    input: resumeEnvelope(runId),
+  });
+  assert.equal(result.code, 0, result.stderr);
+  const receipt = JSON.parse(result.stdout);
+  assert.equal(receipt.status, "completed");
+  assert.equal(receipt.publication.number, publication.number);
+  const events = (await readFile(path.join(directory, runId, "events.jsonl"), "utf8"))
+    .trim().split("\n").map(line => JSON.parse(line));
+  assert.deepEqual(events.map(event => event.type), [
+    "publication.ready", "publication.finished", "run.finished",
+  ]);
+  const record = JSON.parse(await readFile(path.join(directory, runId, "run.json"), "utf8"));
+  assert.equal(record.status, "completed");
+  assert.equal(record.phase, "published");
+});
+
+test("internal-publish-resume fails closed without durable publication evidence", async t => {
+  const { directory, runId } = await fakePublicationStore(t, { ready: false });
+  const result = await invoke(["internal-publish-resume", "--state-root", directory], {
+    input: resumeEnvelope(runId),
+  });
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /run has no unique publication\.ready record/);
+
+  for (const [input, pattern] of [
+    [{ version: 1, runId, token: "not-a-token" }, /publisher resume envelope is invalid/],
+    [{ version: 1, runId, token: `github_pat_${"g".repeat(64)}`, extra: true }, /invalid shape/],
+  ]) {
+    const rejected = await invoke(["internal-publish-resume", "--state-root", directory], {
+      input: JSON.stringify(input),
+    });
+    assert.equal(rejected.code, 1);
+    assert.match(rejected.stderr, pattern);
+  }
+});
+
+test("help covers the cancel and publish commands", async () => {
+  for (const command of ["cancel", "publish"]) {
+    const result = await invoke(["help", command]);
+    assert.equal(result.code, 0, result.stderr);
+    assert.match(result.stdout, new RegExp(`^bimo ${command} --deployment NAME`));
+  }
+  const usageText = await invoke(["help"]);
+  assert.match(usageText.stdout, /^ {2}bimo cancel --deployment NAME/m);
+  assert.match(usageText.stdout, /^ {2}bimo publish --deployment NAME/m);
 });


### PR DESCRIPTION
Refs #7

## What

Three operator-recovery checkboxes from #7, composed with the read path that landed in #26:

1. **Early run ID + bounded progress.** `organize` and `deploy` print `run: <id>` on stderr as soon as the run ID exists, then stream bounded progress: run events tailed from the durable `events.jsonl` via the existing `internal-tail` read container (2s poll, offset cursor, 320-char line cap, no control codes), plus a 30s heartbeat (`still working (<phase>, <elapsed>s)`) during quiet phases like image build. The workflow controller envelope now carries a CLI-generated `runId` (organize/pod already had one CLI-side), so `deploy react-app` can also print its run ID before the controller starts. With `--json`, all progress output is suppressed: stderr stays clean and stdout carries only the final receipt.
2. **Safe cancel + idempotent resume.** New `bimo cancel --deployment NAME [--run ID] [target flags] [--json]` sends SIGTERM via `docker kill --signal SIGTERM` to `bimo-<name>-controller`, then `bimo-<name>-publisher`; the in-container controllers (`runController`/`runPodController`/`runOrganizerController`) already handle SIGINT/SIGTERM by cancelling the runtime and finishing the run durably. `--run` first reads `internal-status` and refuses to signal when the named run is already terminal. New `bimo publish --deployment NAME [--run ID] --github-secret-ref op://... [target flags] [--json]` runs a new `internal-publish-resume` command in the same sandboxed publisher container as deploy; it derives the publication binding from the durable `publication.ready` record and replays `publishRun`, whose existing idempotency guarantees an already completed publication returns its receipt with zero new side effects.
3. **JSON error receipts.** When `--json` is present and a command fails, stdout gets a single-line `{"ok":false,"error":{"command":...,"message":...}}` (matching `doctor`'s `ok` convention, message control-stripped and capped); the human `bimo: <msg>` stays on stderr and the exit code stays 1.

## Design decisions

- **Progress goes to stderr, human mode only.** stdout stays receipt-only in both modes; in `--json` mode progress is suppressed entirely rather than emitted as JSON lines, matching the existing convention that `--json` commands print exactly one machine-readable payload. Operators wanting machine-readable progress can run `logs --follow --json` in another shell.
- **Cancel is signal-based, not a durable flag.** I checked: no controller polls a durable cancel flag in the state root, so the honest minimal version is SIGTERM to the well-known container names — the controllers' existing signal handlers do the graceful cancel (runtime.cancel() → bounded teardown → durable run finish). Cancelling the *publisher* container mid-flight is safe precisely because publication is idempotent and resumable via `bimo publish`. Limitation: a wedged container that ignores SIGTERM needs an operator `docker kill` (SIGKILL); the run record then stays `running` until state is reconciled — documented here rather than papered over with a flag nothing polls.
- **Resume derives authority from durable state, not CLI input.** `internal-publish-resume` takes only `{version, runId, token}`; `baseSha`/`candidateSha`/`headBranch` come from the run's own `publication.ready` event inside the locked-down container and are re-validated by `publishRun`'s existing `readyMatches` check. Runs that failed before `publication.ready` (source already discarded) fail closed with `run is not publication-ready`.
- **`internal-publish-resume --state-root`** mirrors the testability precedent of `internal-runs`/`internal-status`/`internal-tail`.

## Tests

233 → 245, all green (`npm test`, zero-dep `node --test`); `node --check` clean on changed files.

- JSON error receipt shape on failure with/without `--json`.
- Heartbeat unit test (bounded lines, stops cleanly); progress-stream unit test (offset cursor, line cap, tolerates missing run).
- Human-mode `organize` prints `run: <id>` on stderr first; existing `--json` tests still assert empty stderr.
- `cancel`: signals controller/publisher via `docker kill --signal SIGTERM`, fails closed when nothing is running, `--run` guard refuses terminal runs, option validation before any Docker call.
- `publish` CLI path: isolated publisher container (no docker.sock/worktrees/snapshots mounts), exact `{runId, token, version}` envelope, token never logged.
- `internal-publish-resume` against real pod-run stores: completed publication replays with zero new events/Git/API calls; interrupted publication (receipt appended, run not finished) only finishes the run; missing `publication.ready` fails closed; envelope violations rejected.
- Existing `internal-run` test updated for the new `runId` envelope field; fake tool stubs now echo the CLI-generated run ID.

## Files

- `src/bimo.mjs` — run-ID hoisting, `startRunHeartbeat`/`streamRunProgress`, `remoteCancel`, `remotePublish`, `internalPublishResume`, `internal-run` envelope field, JSON error wrapper, usage/help.
- `test/cli.test.mjs` — 12 new tests, harness stub extensions (docker kill, publish-resume, runId echo).
- `README.md` — terse "Progress, cancel, and resume" section.
