### PR TITLE
Define and prove the data-only template boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,10 @@ This is the complete bundled `react-app` manifest:
 The manifest cannot contain commands, images, executables, provider keys, or
 arbitrary environment variables. It declares bounded roles, transitions,
 timeouts, and static-output checks. Markdown prompts describe how each role
-should behave.
+should behave. The exact boundary — what a template may declare, how it is
+validated and digest-bound, what an operator may customize, and what is
+explicitly not promised — is defined in
+[the template boundary](docs/templates.md).
 
 ## What happens during a sequential deployment
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -1,0 +1,155 @@
+# Template boundary
+
+A Bimo template is a data-only pack: one directory under the packaged
+`templates/` root holding one JSON manifest and one Markdown prompt per role.
+The manifest is parsed with `JSON.parse` and checked against an exact-field
+schema; the prompts are instruction text the controller quotes into the agent
+prompt as data. No field in either file is executed, interpolated into a
+command, or registered as code.
+
+This document defines what a template is, what an operator may change, and
+what Bimo explicitly does not promise. It is the template-side counterpart of
+[docs/targets.md](targets.md) and [docs/runtime-contract.md](runtime-contract.md):
+same discipline, closed registries, evidence over speculation.
+
+## What a template is
+
+Two kinds exist, dispatched by which manifest file the directory contains
+(`loadTemplate`, `src/bimo.mjs:278-302`):
+
+- **Sequential workflow** — `workflow.json` plus one prompt file per role
+  (`src/workflow.mjs`). Declares `version`, `name`, `start`, `maxSteps`,
+  `timeouts`, `roles`, and `output`. Each role declares exactly `prompt`,
+  `write`, and `on` (the receipt-outcome transition table). Bounds: 1–12
+  roles, 1–8 transitions per role, `maxSteps` 1–20, step and workflow
+  timeouts, an output directory of one safe path component, file and byte
+  caps, and one static smoke check (`validateWorkflow`,
+  `src/workflow.mjs:149-221`). The start role must reach `done` and no role
+  may be unreachable (`src/workflow.mjs:185-199`).
+- **Engineering pod** — `pod.json` plus the fixed prompt files
+  (`src/pod-contract.mjs`). Declares `version`, `name`, `maxAttempts`,
+  `timeouts`, `changes`, `writers`, `prompts`, and `verificationProfile`.
+  The writer slots are exactly `engineering-a`, `engineering-b`, `qa-tests`;
+  the prompt slots are exactly `planner`, `checker`, `qa`, `testing`
+  (`src/pod-contract.mjs:15-17`, enforced at `src/pod-contract.mjs:401` and
+  `src/pod-contract.mjs:421-425`). Each writer gets exactly one
+  `allowedWriteRoots` directory; roots must be canonical portable relative
+  directories, pairwise disjoint even under case folding, and may never name
+  `.git` or `.github` (`src/pod-contract.mjs:408-417`,
+  `src/pod-contract.mjs:137-154`). `verificationProfile` is a closed set of
+  one value, `bimo-repo-v1` (`src/pod-contract.mjs:81`,
+  `src/pod-contract.mjs:426-431`).
+
+Both loaders then enforce the filesystem boundary: the manifest is a regular
+file no larger than 64 KiB; every prompt is a regular file — never a symlink —
+that resolves inside the template directory and is no larger than 32 KiB with
+no unsafe control characters; the directory name must equal the manifest name;
+a symlinked template directory is not a template at all
+(`src/workflow.mjs:223-262`, `src/pod-contract.mjs:435-493`).
+
+## The digest
+
+Every load computes one SHA-256 over the raw manifest bytes and each prompt's
+path and content (`src/workflow.mjs:247-260`,
+`src/pod-contract.mjs:471-485`). The digest is the template's identity:
+
+- `bimo validate TEMPLATE` prints it (`src/bimo.mjs:2430-2436`).
+- The organizer catalog binds each template name to its digest, and a
+  selector receipt is valid only when name and digest are copied from the
+  same installed row (`src/organize.mjs:162-166`).
+- Deploy carries the digest in the controller envelope; the in-image
+  controller reloads the template from the image-baked copy and fails closed
+  on any mismatch (`src/bimo.mjs:1267-1268`, `src/bimo.mjs:1393-1396`).
+  Templates are baked into the image at build time (`Dockerfile:37`).
+
+One changed byte in a manifest or prompt changes the digest, and a changed
+digest stops the run before Docker or Git work begins.
+
+## What an operator may change today
+
+The template root is the installed package's `templates/` directory and
+nothing else (`src/bimo.mjs:39`). Template names are lowercase names, not
+paths, so `bimo list`, `bimo validate`, `bimo deploy`, and `bimo organize`
+can only ever address directories inside that root. There is no
+`--template-dir` flag, no user template directory, and no profile registry.
+
+The supported customization path is a fork: edit or add template directories
+in a private copy of the package, rebuild the image so the same bytes are
+baked in, and deploy with `--image`. The validation above is the boundary a
+forked template must satisfy — it is enforced identically on the operator
+machine and inside the controller, so a forked template cannot smuggle in
+shape the packaged ones are denied.
+
+Within a forked manifest, the legitimate knobs are data: role and transition
+declarations within the numeric bounds, prompt text, timeouts, output caps,
+the smoke check, and — for the pod — the three write roots, the attempt and
+change bounds, and prompt text. The pod topology itself is fixed in
+controller code, not in `pod.json`: the pod controller accepts only the
+`parallel-engineering-pod` template name (`src/bimo.mjs:1382`), so a forked
+pod can retune prompts, roots, and bounds but cannot rename, resize, or
+re-wire the pod without changing controller code.
+
+## What a template cannot do
+
+Enforced by validation and cited tests:
+
+- **Carry executable content.** Exact-field schemas reject any unknown key —
+  a `command`, `args`, `executable`, `hooks`, `image`, `env`, or similar
+  field fails validation (`assertExactFields`, `src/workflow.mjs:44-51`;
+  `src/pod-contract.mjs:103-110`; tests at `test/workflow.test.mjs:58-61`
+  and `test/pod-contract.test.mjs:130-133`).
+- **Escape its directory.** Prompt paths are canonical relative paths, and
+  each prompt is re-checked with `realpath` against the template directory
+  (`src/workflow.mjs:249-256`, `src/pod-contract.mjs:472-481`).
+- **Escape its write authority.** A workflow role's `write` boolean is the
+  whole decision; the runtime mounts the workspace read-only for `write:
+  false` roles (`src/workflow.mjs:536,545`,
+  `src/docker-runtime.mjs:59-74`). Pod write roots are validated as above,
+  and planner-assigned `writePaths` must subdivide existing directories
+  inside the writer's template-owned root (`src/pod-contract.mjs:585-597`;
+  tests at `test/pod-contract.test.mjs:155-198` and
+  `test/pod-contract.test.mjs:352`).
+- **Arrive tampered.** A digest mismatch between the operator CLI and the
+  controller fails the run before Docker or Git work
+  (`test/cli.test.mjs:908-959`).
+- **Choose operational authority.** Templates cannot name a target, runtime,
+  image, command, credential, repository, provider, or model. Target
+  authority stays in the operator CLI ([docs/targets.md](targets.md));
+  runtime authority likewise
+  ([docs/runtime-contract.md](runtime-contract.md)); organizer agents are
+  instructed never to propose template content and their receipts are
+  validated against the digest-bound catalog
+  (`etc/organizer/organizer.md`, `src/organize.mjs:150-172`).
+
+## Non-promises
+
+- No executable plugins, hooks, or template-supplied code — now or as a
+  roadmap commitment. A template never adds behavior; it declares bounds on
+  behavior the controller already implements.
+- No user-supplied template directory, template discovery, or template
+  marketplace. The supported set is the packaged root plus private forks.
+- No user-registered verification profiles, runtimes, verifiers, or
+  publishers. `verificationProfile` is a closed set; the runtime registry is
+  closed and built-in ([docs/runtime-contract.md](runtime-contract.md)).
+- No general DAG or graph engine. The sequential kind is one bounded state
+  machine; the pod kind is one fixed product path.
+
+If any of these is ever reconsidered, it lands the same way the target and
+runtime seams do: as a built-in behind the closed registry, with end-to-end
+evidence, before any external boundary is promised.
+
+## Proof
+
+The boundary holds in tests:
+
+- `test/workflow.test.mjs` — the packaged workflow loads; unknown fields,
+  multi-component output directories, and the reserved smoke path are
+  rejected; template loading fails closed on a name mismatch, a symlinked
+  template directory, an escaping prompt path, a symlinked prompt, an
+  oversized manifest, and a one-byte prompt tamper changes the digest.
+- `test/pod-contract.test.mjs` — executable fields, extra writers, and
+  unsupported profiles are rejected; write roots are canonical, disjoint,
+  and exclude repository control paths; pod loading fails closed on the same
+  filesystem boundary and digest tamper class.
+- `test/cli.test.mjs` — `internal-run` and `internal-pod-run` reject an
+  invalid or mismatched template digest before Docker or Git work.

--- a/test/pod-contract.test.mjs
+++ b/test/pod-contract.test.mjs
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
@@ -193,6 +195,69 @@ test("template-owned write roots are canonical, disjoint, and exclude control pa
   const caseOverlap = podTemplate();
   caseOverlap.writers["engineering-b"].allowedWriteRoots = ["SRC"];
   assert.throws(() => validatePodTemplate(caseOverlap), /write roots overlap/);
+});
+
+test("pod template loading fails closed at the template-root filesystem boundary", async () => {
+  const temporary = await mkdtemp(path.join(os.tmpdir(), "bimo-pod-template-"));
+  const templateRoot = path.join(temporary, "templates");
+  const outside = path.join(temporary, "outside.md");
+  await writeFile(outside, "instructions that live outside the template");
+
+  async function writePod(name, { manifestName = name } = {}) {
+    const directory = path.join(templateRoot, name);
+    await mkdir(path.join(directory, "roles"), { recursive: true });
+    const manifest = podTemplate();
+    manifest.name = manifestName;
+    await writeFile(path.join(directory, "pod.json"), JSON.stringify(manifest));
+    const prompts = {
+      "engineering.md": "Engineer inside the assigned write root.",
+      "qa-tests.md": "Write tests only.",
+      "planner.md": "Plan the attempt.",
+      "checker.md": "Check the exact diff.",
+      "qa.md": "Review read-only.",
+      "testing.md": "Run the fixed profile.",
+    };
+    for (const [file, content] of Object.entries(prompts)) {
+      await writeFile(path.join(directory, "roles", file), content);
+    }
+    return directory;
+  }
+
+  await writePod("parallel-engineering-pod");
+  const loaded = await loadPodTemplate("parallel-engineering-pod", { templateRoot });
+  assert.match(loaded.templateDigest, /^[a-f0-9]{64}$/);
+
+  // The directory name and the manifest name must agree.
+  await writePod("renamed-pod", { manifestName: "other-pod" });
+  await assert.rejects(loadPodTemplate("renamed-pod", { templateRoot }), /does not match pod template name/);
+
+  // A symlinked template directory is not a template.
+  await symlink(
+    path.join(templateRoot, "parallel-engineering-pod"),
+    path.join(templateRoot, "linked-pod"),
+  );
+  await assert.rejects(loadPodTemplate("linked-pod", { templateRoot }), /unknown pod template/);
+
+  // A prompt that is a symlink to an outside file is not a regular file.
+  const linkedPrompt = await writePod("linked-prompt-pod");
+  await rm(path.join(linkedPrompt, "roles", "planner.md"));
+  await symlink(outside, path.join(linkedPrompt, "roles", "planner.md"));
+  await assert.rejects(
+    loadPodTemplate("linked-prompt-pod", { templateRoot }),
+    /must be a regular file/,
+  );
+
+  // The manifest is size-capped before parsing.
+  const oversized = await writePod("oversized-pod");
+  await writeFile(path.join(oversized, "pod.json"), `{${" ".repeat(65 * 1024)}`);
+  await assert.rejects(loadPodTemplate("oversized-pod", { templateRoot }), /exceeds 64 KiB/);
+
+  // The digest binds every prompt byte: one changed byte changes the digest.
+  const tampered = await writePod("tampered-pod");
+  const before = await loadPodTemplate("tampered-pod", { templateRoot });
+  await writeFile(path.join(tampered, "roles", "planner.md"), "Plan the attempt, differently.");
+  const after = await loadPodTemplate("tampered-pod", { templateRoot });
+  assert.notEqual(after.templateDigest, before.templateDigest);
 });
 
 test("the packaged pod loads all fixed prompts with a stable digest", async () => {

--- a/test/workflow.test.mjs
+++ b/test/workflow.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, readFile, readdir, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -71,6 +71,70 @@ test("the packaged React workflow is data-only and bounded", async () => {
   const reservedSmoke = structuredClone(loaded.workflow);
   reservedSmoke.output.smoke.path = "/healthz";
   assert.throws(() => validateWorkflow(reservedSmoke), /reserved for server health/);
+});
+
+test("template loading fails closed at the template-root filesystem boundary", async () => {
+  const temporary = await mkdtemp(path.join(os.tmpdir(), "bimo-template-"));
+  const templateRoot = path.join(temporary, "templates");
+  const outside = path.join(temporary, "outside.md");
+  await writeFile(outside, "instructions that live outside the template");
+
+  async function writeTemplate(name, { manifestName = name, promptPath = "roles/engineering.md", prompt = "Do the bounded role." } = {}) {
+    const directory = path.join(templateRoot, name);
+    await mkdir(path.join(directory, "roles"), { recursive: true });
+    const manifest = {
+      version: 1,
+      name: manifestName,
+      start: "engineering",
+      maxSteps: 4,
+      timeouts: { stepSeconds: 60, workflowSeconds: 600 },
+      roles: {
+        engineering: { prompt: promptPath, write: true, on: { completed: "done" } },
+      },
+      output: {
+        directory: "dist",
+        maxFiles: 10,
+        maxBytes: 65_536,
+        smoke: { path: "/", status: 200, contains: "READY" },
+      },
+    };
+    await writeFile(path.join(directory, "workflow.json"), JSON.stringify(manifest));
+    await writeFile(path.join(directory, "roles", "engineering.md"), prompt);
+    return directory;
+  }
+
+  await writeTemplate("sample");
+  const loaded = await loadWorkflow("sample", { templateRoot });
+  assert.match(loaded.templateDigest, /^[a-f0-9]{64}$/);
+
+  // The directory name and the manifest name must agree.
+  await writeTemplate("renamed", { manifestName: "sample" });
+  await assert.rejects(loadWorkflow("renamed", { templateRoot }), /does not match workflow name/);
+
+  // A symlinked template directory is not a template.
+  await symlink(path.join(templateRoot, "sample"), path.join(templateRoot, "linked"));
+  await assert.rejects(loadWorkflow("linked", { templateRoot }), /unknown template/);
+
+  // A prompt path that escapes the template is rejected before any file is read.
+  await writeTemplate("escaping", { promptPath: "../outside.md" });
+  await assert.rejects(loadWorkflow("escaping", { templateRoot }), /relative workspace path/);
+
+  // A prompt that is a symlink to an outside file is not a regular file.
+  const linkedPrompt = await writeTemplate("linked-prompt");
+  await rm(path.join(linkedPrompt, "roles", "engineering.md"));
+  await symlink(outside, path.join(linkedPrompt, "roles", "engineering.md"));
+  await assert.rejects(loadWorkflow("linked-prompt", { templateRoot }), /prompt must be a regular file/);
+
+  // The manifest is size-capped before parsing.
+  const oversized = await writeTemplate("oversized");
+  await writeFile(path.join(oversized, "workflow.json"), `{${" ".repeat(65 * 1024)}`);
+  await assert.rejects(loadWorkflow("oversized", { templateRoot }), /exceeds 64 KiB/);
+
+  // The digest binds every prompt byte: one changed byte changes the digest.
+  const tampered = path.join(templateRoot, "sample", "roles", "engineering.md");
+  await writeFile(tampered, "Do the bounded role, differently.");
+  const reloaded = await loadWorkflow("sample", { templateRoot });
+  assert.notEqual(reloaded.templateDigest, loaded.templateDigest);
 });
 
 test("strict receipts reject extra fields and unsafe paths", () => {


### PR DESCRIPTION
Refs #7

## What this does

Defines the supported template/profile boundary in `docs/templates.md` and proves it with tests, without promising arbitrary executable plugins.

- **`docs/templates.md`** — the boundary, grounded in the validation code with file:line citations: what a template is (data-only JSON manifest + Markdown prompts), the digest as template identity, what an operator may change today (fork-only; the template root is the packaged `templates/` directory), what a template cannot do, and the explicit non-promises (no executable plugins, no user template directory or registry, no user-registered profiles/runtimes/verifiers).
- **Proof tests** — the load-time filesystem boundary rules that existed in code but were untested: manifest name ≠ directory name, symlinked template directory, escaping prompt path, symlinked prompt, oversized manifest, and one-byte prompt tamper changing the digest — for both `loadWorkflow` and `loadPodTemplate`.
- **README** — one short paragraph linking the boundary doc where templates are introduced.

## Honest findings (not papered over)

- There is **no user-supplied template path or profile mechanism**: `templateRoot` is hardcoded to the package root (`src/bimo.mjs:39`), template names are regex-bound names (not paths), and there is no `--template-dir` flag. The doc states customization is fork-only rather than implying a drop-in mechanism exists.
- The pod controller accepts only the literal `parallel-engineering-pod` template name (`src/bimo.mjs:1382`), so a forked pod manifest cannot deploy under a new name without controller changes. The doc states this asymmetry (workflow kind has no such hardcode).
- `verificationProfile` is a closed set of exactly one value (`src/pod-contract.mjs:81`).

`npm test`: 247 passing (245 on main + 2 new boundary tests).