### PR TITLE
Harden read paths against implicit pulls and clarify alpha error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,8 +308,12 @@ bimo help doctor
 ```
 
 `logs --follow` replays the run's events from the start and then polls for new
-ones until interrupted. `bimo help COMMAND` (or `bimo COMMAND --help`) prints a
-command-specific synopsis; bare `bimo help` keeps the full usage.
+ones until interrupted. With no recorded runs, `logs` prints `no runs recorded
+for deployment NAME` and exits 0. If the workflow image is not built on the
+target yet, the read commands report that (and a still-preparing run under
+`--follow`) instead of attempting a pull. `bimo help COMMAND` (or `bimo
+COMMAND --help`) prints a command-specific synopsis; bare `bimo help` keeps
+the full usage.
 
 ### Progress, cancel, and resume
 
@@ -531,7 +535,9 @@ image tag `bimo-workflow:0.5.0`. `--account` selects a 1Password account;
 
 Quote each `op://` reference as one shell argument. Vault, item, and field names
 may contain literal spaces; Bimo passes the validated reference directly to
-`op read` without invoking a shell.
+`op read` without invoking a shell. Secret references are resolved before any
+image build work, so a missing or unauthenticated 1Password CLI fails fast
+with an install hint instead of a raw spawn error.
 
 `--public-url` is only the address Bimo records and reports for the published
 port. Bimo does not create DNS records, TLS certificates, firewall rules,

--- a/bin/bimo
+++ b/bin/bimo
@@ -22,9 +22,9 @@ if (command === "source-verify") {
     process.argv.splice(2, 1);
     await import(internal.get(command));
   } else {
-    const { main } = await import("../src/bimo.mjs");
+    const { main, collapseBimoPrefixes } = await import("../src/bimo.mjs");
     main().catch(error => {
-      process.stderr.write(`bimo: ${error.message}\n`);
+      process.stderr.write(`bimo: ${collapseBimoPrefixes(error.message)}\n`);
       process.exitCode = 1;
     });
   }

--- a/docs/runtime-contract.md
+++ b/docs/runtime-contract.md
@@ -27,7 +27,11 @@ express one, the adapter fails closed; it does not silently degrade.
    for the runtime, and prove identity after transfer: Bimo today builds for
    the target platform, transfers with `docker save`/`load`, and compares
    content fingerprints on both sides (`prepareImage` in `src/bimo.mjs`).
-   The runtime never pulls a mutable reference at run time.
+   The runtime never pulls a mutable reference at run time: every
+   `docker run`/`create` is pinned with `--pull=never`, and the read paths
+   (`logs`, `runs`, `status`, `cancel`, `publish`) preflight local image
+   presence and fail closed with a build hint instead of letting Docker
+   attempt an implicit pull.
 2. **Provision the deployment environment.** Create the isolated internal
    network, the separate egress network, and the run-scoped credential
    gateway, then health-probe the gateway before any agent starts

--- a/src/bimo.mjs
+++ b/src/bimo.mjs
@@ -564,6 +564,22 @@ async function cleanupTransferredImage(target, transferTag) {
   await execute("docker", ["image", "rm", "-f", transferTag], { timeoutMs: 30_000 }).catch(() => {});
 }
 
+async function requireImagePresent(target, image, { preparing = false } = {}) {
+  const missing = await targetExecute(target, ["docker", "image", "inspect", image], {
+    timeoutMs: 15_000,
+    maxOutputBytes: 4 * 1024,
+  }).then(() => false, error => {
+    if (/no such image/i.test(error instanceof Error ? error.message : String(error))) return true;
+    throw error;
+  });
+  if (!missing) return;
+  const where = target.kind === "local" ? "locally" : "on the target";
+  if (preparing) {
+    fail(`bimo image ${image} is not built ${where} yet; the run is still preparing its image`);
+  }
+  fail(`bimo image ${image} is not built ${where} yet; run bimo deploy first`);
+}
+
 async function validateLocalStateChain(home, hostRoot, { allowMissing }) {
   const relative = path.relative(home, hostRoot);
   if (!relative || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
@@ -596,7 +612,7 @@ async function prepareLocalState(target, image, hostRoot, layout) {
   deploymentDirectories(layout);
   await ensureLocalStateRoot(target, hostRoot);
   await targetExecute(target, [
-    "docker", "run", "--rm",
+    "docker", "run", "--pull=never", "--rm",
     "--user", "0:0",
     "--network", "none",
     "--read-only",
@@ -683,12 +699,24 @@ function parseImageInspect(raw, label) {
   };
 }
 
-async function resolveSecret(reference, account) {
-  if (!SECRET_REF.test(reference)) fail("--secret-ref must be a 1Password op:// reference");
+async function opRead(reference, account, flag) {
   const args = ["read", reference];
   if (account) args.push("--account", account);
-  const result = await execute("op", args, { maxOutputBytes: 4 * 1024 });
-  const secret = result.stdout.trim();
+  let result;
+  try {
+    result = await execute("op", args, { maxOutputBytes: 4 * 1024 });
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      fail(`1Password CLI (\`op\`) not found; it is required to resolve ${flag} (install: https://developer.1password.com/docs/cli/get-started/)`);
+    }
+    fail(`failed to resolve ${flag} via 1Password: ${errorReceiptMessage(error)}`);
+  }
+  return result.stdout.trim();
+}
+
+async function resolveSecret(reference, account) {
+  if (!SECRET_REF.test(reference)) fail("--secret-ref must be a 1Password op:// reference");
+  const secret = await opRead(reference, account, "--secret-ref");
   if (!/^sk-or-v1-[A-Za-z0-9_-]{32,}$/.test(secret)) fail("1Password reference did not resolve to an OpenRouter key");
   return secret;
 }
@@ -787,10 +815,7 @@ async function resolveGitHubSecret(reference, account) {
   if (!SECRET_REF.test(reference ?? "")) {
     fail("--github-secret-ref must be a 1Password op:// reference");
   }
-  const args = ["read", reference];
-  if (account) args.push("--account", account);
-  const result = await execute("op", args, { maxOutputBytes: 4 * 1024 });
-  const secret = result.stdout.trim();
+  const secret = await opRead(reference, account, "--github-secret-ref");
   if (!GITHUB_TOKEN.test(secret)) fail("1Password reference did not resolve to a GitHub token");
   return secret;
 }
@@ -841,6 +866,10 @@ async function deploy(template, options) {
   let follower = null;
   let transferTag = null;
   try {
+    let openRouterKey = await resolveSecret(options["secret-ref"], options.account);
+    let githubToken = pod
+      ? await resolveGitHubSecret(options["github-secret-ref"], options.account)
+      : null;
     heartbeat?.setPhase("preparing image");
     const prepared = await prepareImage(deploymentTarget, image);
     const remoteImage = prepared.remoteImage;
@@ -865,7 +894,6 @@ async function deploy(template, options) {
     }
     if (pod) {
       await prepareDeploymentState(deploymentTarget, remoteImage.imageId, hostRoot, "pod");
-      let openRouterKey = await resolveSecret(options["secret-ref"], options.account);
       const computeEnvelope = JSON.stringify({
         version: 1,
         template: loaded.template.name,
@@ -883,7 +911,7 @@ async function deploy(template, options) {
       openRouterKey = "";
       const controllerName = `bimo-${options.deployment}-controller`;
       const compute = await targetExecute(deploymentTarget, [
-        "docker", "run", "--rm", "-i",
+        "docker", "run", "--pull=never", "--rm", "-i",
         "--name", controllerName,
         "--user", "0:0",
         "--read-only",
@@ -913,7 +941,6 @@ async function deploy(template, options) {
         baseSha: options["base-sha"],
       });
 
-      let githubToken = await resolveGitHubSecret(options["github-secret-ref"], options.account);
       const publishEnvelope = JSON.stringify({
         version: 1,
         runId,
@@ -927,7 +954,7 @@ async function deploy(template, options) {
       githubToken = "";
       heartbeat?.setPhase("publishing");
       const publisher = await targetExecute(deploymentTarget, [
-        "docker", "run", "--rm", "-i",
+        "docker", "run", "--pull=never", "--rm", "-i",
         "--name", `bimo-${options.deployment}-publisher`,
         "--user", "0:0",
         "--read-only",
@@ -955,14 +982,13 @@ async function deploy(template, options) {
     } else {
       await prepareDeploymentState(deploymentTarget, remoteImage.imageId, hostRoot, "workflow");
 
-      const secret = await resolveSecret(options["secret-ref"], options.account);
       const envelope = JSON.stringify({
         version: 1,
         template: loaded.workflow.name,
         templateDigest: loaded.templateDigest,
         deployment: options.deployment,
         task,
-        key: secret,
+        key: openRouterKey,
         model,
         image: remoteImage.imageId,
         port,
@@ -971,7 +997,7 @@ async function deploy(template, options) {
       });
       const controllerName = `bimo-${options.deployment}-controller`;
       const result = await targetExecute(deploymentTarget, [
-        "docker", "run", "--rm", "-i",
+        "docker", "run", "--pull=never", "--rm", "-i",
         "--name", controllerName,
         "--user", "0:0",
         "--read-only",
@@ -1034,6 +1060,7 @@ async function organizeRemote(options) {
   let follower = null;
   let transferTag = null;
   try {
+    let openRouterKey = await resolveSecret(options["secret-ref"], options.account);
     heartbeat?.setPhase("preparing image");
     const prepared = await prepareImage(deploymentTarget, image, { retag: false });
     const remoteImage = prepared.remoteImage;
@@ -1057,7 +1084,6 @@ async function organizeRemote(options) {
       }).catch(() => {});
     }
     await prepareDeploymentState(deploymentTarget, remoteImage.imageId, hostRoot, "organizer");
-    let openRouterKey = await resolveSecret(options["secret-ref"], options.account);
     const envelope = JSON.stringify({
       version: 1,
       deployment: options.deployment,
@@ -1070,7 +1096,7 @@ async function organizeRemote(options) {
     });
     openRouterKey = "";
     const result = await targetExecute(deploymentTarget, [
-      "docker", "run", "--rm", "-i",
+      "docker", "run", "--pull=never", "--rm", "-i",
       "--name", `bimo-${options.deployment}-controller`,
       "--user", "0:0",
       "--read-only",
@@ -1494,9 +1520,10 @@ async function internalPublishResume(options) {
     runId = (await readFile(path.join(stateRoot, "latest"), "utf8").catch(() => "")).trim();
     if (!RUN_ID.test(runId)) fail("no latest run is recorded");
   }
-  const store = await openPodRunStore({ stateRoot, runId });
+  const store = await openPodRunStore({ stateRoot, runId })
+    .catch(() => fail(`no publication-ready record found for run ${runId}`));
   const ready = store.events.filter(event => event.type === "publication.ready");
-  if (ready.length !== 1) fail("run has no unique publication.ready record");
+  if (ready.length !== 1) fail(`no publication-ready record found for run ${runId}`);
   const { repository, targetBranch, baseSha, candidateSha, headBranch } = ready[0];
   if (repository !== POD_REPOSITORY || targetBranch !== POD_TARGET_BRANCH
       || !GIT_SHA.test(baseSha ?? "") || !GIT_SHA.test(candidateSha ?? "")
@@ -1617,12 +1644,13 @@ async function remoteLogs(options) {
   const image = options.image ?? DEFAULT_IMAGE;
   if (!IMAGE.test(image)) fail("--image is invalid");
   const hostRoot = deploymentRootForTarget(deploymentTarget, options.deployment);
+  await requireImagePresent(deploymentTarget, image, { preparing: Boolean(options.follow) });
   if (options.follow) {
     await followLogs(deploymentTarget, { hostRoot, image, runId, json: Boolean(options.json) });
     return;
   }
   const result = await targetExecute(deploymentTarget, [
-    "docker", "run", "--rm", "--read-only", "--network", "none",
+    "docker", "run", "--pull=never", "--rm", "--read-only", "--network", "none",
     "--user", "0:0",
     "--cap-drop", "ALL",
     "--security-opt", "no-new-privileges",
@@ -1632,6 +1660,7 @@ async function remoteLogs(options) {
     "--volume", `${hostRoot}/runs:/state:ro`,
     image,
     "internal-logs",
+    "--deployment", options.deployment,
     "--run", runId,
     ...(options.json ? ["--json"] : []),
   ], { maxOutputBytes: 2 * 1024 * 1024 });
@@ -1641,11 +1670,23 @@ async function remoteLogs(options) {
 async function internalLogs(argv) {
   const { positional, options } = parseOptions(argv, { booleans: ["json"] });
   if (positional.length) fail("internal-logs accepts no positional arguments");
-  exactOptions(options, ["run", "json"]);
+  exactOptions(options, ["deployment", "run", "state-root", "json"]);
+  if (!NAME.test(options.deployment ?? "")) fail("--deployment is invalid");
+  const stateRoot = internalStateRoot(options);
   let runId = options.run ?? "latest";
-  if (runId === "latest") runId = (await readFile("/state/latest", "utf8")).trim();
+  if (runId === "latest") {
+    runId = (await readFile(path.join(stateRoot, "latest"), "utf8").catch(() => "")).trim();
+    if (!runId) {
+      if (options.json) {
+        process.stdout.write(`${JSON.stringify({ deployment: options.deployment, run: null, events: [] })}\n`);
+      } else {
+        process.stdout.write(`no runs recorded for deployment ${options.deployment}\n`);
+      }
+      return;
+    }
+  }
   if (!RUN_ID.test(runId)) fail("invalid run ID");
-  const runDir = path.join("/state", runId);
+  const runDir = path.join(stateRoot, runId);
   const stat = await lstat(runDir).catch(() => null);
   if (!stat?.isDirectory() || stat.isSymbolicLink()) fail(`unknown run: ${runId}`);
   const targetPath = path.join(runDir, options.json ? "events.jsonl" : "CHANGELOG.md");
@@ -1904,7 +1945,7 @@ async function internalTail(argv) {
 
 function stateReadArgs(hostRoot, image, internalArgs) {
   return [
-    "docker", "run", "--rm", "--read-only", "--network", "none",
+    "docker", "run", "--pull=never", "--rm", "--read-only", "--network", "none",
     "--user", "0:0",
     "--cap-drop", "ALL",
     "--security-opt", "no-new-privileges",
@@ -1925,6 +1966,7 @@ async function remoteRuns(options) {
   const image = options.image ?? DEFAULT_IMAGE;
   if (!IMAGE.test(image)) fail("--image is invalid");
   const hostRoot = deploymentRootForTarget(deploymentTarget, options.deployment);
+  await requireImagePresent(deploymentTarget, image);
   const result = await targetExecute(deploymentTarget, stateReadArgs(hostRoot, image, [
     "internal-runs",
     "--deployment", options.deployment,
@@ -1943,6 +1985,7 @@ async function remoteStatus(options) {
   const image = options.image ?? DEFAULT_IMAGE;
   if (!IMAGE.test(image)) fail("--image is invalid");
   const hostRoot = deploymentRootForTarget(deploymentTarget, options.deployment);
+  await requireImagePresent(deploymentTarget, image);
   const result = await targetExecute(deploymentTarget, stateReadArgs(hostRoot, image, [
     "internal-status",
     "--deployment", options.deployment,
@@ -1963,6 +2006,7 @@ async function remoteCancel(options) {
   if (!IMAGE.test(image)) fail("--image is invalid");
   const hostRoot = deploymentRootForTarget(deploymentTarget, options.deployment);
   if (runId !== null) {
+    await requireImagePresent(deploymentTarget, image);
     const statusResult = await targetExecute(deploymentTarget, stateReadArgs(hostRoot, image, [
       "internal-status",
       "--deployment", options.deployment,
@@ -2038,10 +2082,11 @@ async function remotePublish(options) {
   if (!IMAGE.test(image)) fail("--image is invalid");
   const hostRoot = deploymentRootForTarget(deploymentTarget, options.deployment);
   let githubToken = await resolveGitHubSecret(options["github-secret-ref"], options.account);
+  await requireImagePresent(deploymentTarget, image);
   const envelope = JSON.stringify({ version: 1, runId, token: githubToken });
   githubToken = "";
   const publisher = await targetExecute(deploymentTarget, [
-    "docker", "run", "--rm", "-i",
+    "docker", "run", "--pull=never", "--rm", "-i",
     "--name", `bimo-${options.deployment}-publisher`,
     "--user", "0:0",
     "--read-only",
@@ -2305,6 +2350,11 @@ async function doctor(options) {
       const result = await execute("op", ["--version"], {
         timeoutMs: 15_000,
         maxOutputBytes: 4 * 1024,
+      }).catch(error => {
+        if (error?.code === "ENOENT") {
+          fail("1Password CLI (`op`) not found; it is required to resolve --secret-ref (install: https://developer.1password.com/docs/cli/get-started/)");
+        }
+        throw error;
       });
       const version = result.stdout.trim();
       if (!/^\d+\.\d+[\d.]*$/u.test(version)) fail("op CLI returned an unexpected version");
@@ -2539,11 +2589,16 @@ async function runCommand(argv) {
   fail(`unknown command: ${command}`);
 }
 
+export function collapseBimoPrefixes(message) {
+  return String(message).replace(/([a-z]+ exited \d+: )bimo: /g, "$1");
+}
+
 function errorReceiptMessage(error) {
-  return (error instanceof Error && typeof error.message === "string" ? error.message : String(error))
+  const message = (error instanceof Error && typeof error.message === "string" ? error.message : String(error))
     .replace(/[\u0000-\u001f\u007f]+/gu, " ")
     .trim()
     .slice(0, 500) || "command failed";
+  return collapseBimoPrefixes(message);
 }
 
 export async function main(argv = process.argv.slice(2)) {

--- a/src/docker-runtime.mjs
+++ b/src/docker-runtime.mjs
@@ -268,6 +268,7 @@ export function agentCreateArgs({
   const name = containerName(deployment, nameSuffix);
   return [
     "create",
+    "--pull=never",
     "--name", name,
     ...transientLabels(deployment),
     "--network", network,
@@ -293,6 +294,7 @@ export function agentCreateArgs({
 export function bootstrapArgs({ deployment, image, workspaceHost }) {
   return [
     "run",
+    "--pull=never",
     "--rm",
     "--name", containerName(deployment, "bootstrap"),
     ...transientLabels(deployment),
@@ -326,6 +328,7 @@ export function proxyCreateArgs({
   }
   return [
     "create",
+    "--pull=never",
     "--interactive",
     "--name", containerName(deployment, "gateway"),
     ...transientLabels(deployment),
@@ -402,6 +405,7 @@ export function sourceVerifierCreateArgs({
 
   return [
     "create",
+    "--pull=never",
     "--name", containerName(deployment, nameSuffix),
     ...transientLabels(deployment),
     "--network", "none",
@@ -441,6 +445,7 @@ export function serverCreateArgs({
 }) {
   return [
     "create",
+    "--pull=never",
     "--name", containerName(deployment, nameSuffix),
     ...(transient ? transientLabels(deployment) : []),
     ...(restart ? ["--restart", "unless-stopped"] : []),
@@ -1030,7 +1035,7 @@ export class DockerRuntime {
       this.key = null;
       for (let attempt = 0; attempt < 30; attempt += 1) {
         const probe = await this.commandWithin([
-          "run", "--rm", "--network", this.agentNetwork,
+          "run", "--pull=never", "--rm", "--network", this.agentNetwork,
           ...transientLabels(this.deployment),
           ...commonSandbox({ memory: "64m", cpus: "0.25", pids: "32" }),
           "--tmpfs", "/tmp:rw,nosuid,nodev,noexec,size=16m",
@@ -1337,6 +1342,7 @@ export class DockerRuntime {
       this.activeContainers.add(name);
       const created = await this.commandWithin([
         "create",
+        "--pull=never",
         "--name", name,
         ...transientLabels(this.deployment),
         "--network", "none",

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -104,6 +104,7 @@ async function fakeDeployTools(t, {
   remotePlatform = "linux/amd64",
   localArchitecture = "amd64",
   controller = "conflict",
+  missingOp = false,
 } = {}) {
   const directory = await mkdtemp(path.join(tmpdir(), "bimo-cli-test-"));
   const logFile = path.join(directory, "commands.jsonl");
@@ -118,7 +119,12 @@ fs.appendFileSync(process.env.BIMO_TEST_LOG, JSON.stringify({ tool: "docker", ar
 const log = value => fs.appendFileSync(process.env.BIMO_TEST_LOG, JSON.stringify(value) + "\\n");
 if (args[0] === "context" && args[1] === "inspect") process.stdout.write(process.env.BIMO_TEST_DOCKER_ENDPOINT + "\\n");
 else if (args[0] === "version") process.stdout.write("linux/arm64\\n");
-else if (args[0] === "image" && args[1] === "inspect") process.stdout.write(process.env.BIMO_TEST_LOCAL_INSPECT + "\\n");
+else if (args[0] === "image" && args[1] === "inspect") {
+  if (process.env.BIMO_TEST_IMAGE_MISSING) {
+    process.stderr.write("Error response from daemon: No such image: " + args[args.length - 1] + "\\n");
+    process.exitCode = 1;
+  } else process.stdout.write(process.env.BIMO_TEST_LOCAL_INSPECT + "\\n");
+}
 else if (args[0] === "save") process.stdout.write("fake-image-archive");
 else if (args[0] === "kill") {
   const name = args[args.length - 1];
@@ -129,6 +135,10 @@ else if (args[0] === "kill") {
   }
 }
 else if (args[0] === "run") {
+  if (process.env.BIMO_TEST_READ_FAIL && args.includes("internal-logs")) {
+    process.stderr.write(process.env.BIMO_TEST_READ_FAIL + "\\n");
+    process.exitCode = 1;
+  } else {
   const internalCommand = args.find(value => value === "internal-prepare" || value === "internal-run");
   if (internalCommand === "internal-prepare") process.stdout.write("prepared\\n");
   else {
@@ -151,6 +161,7 @@ else if (args[0] === "run") {
         url: envelope.publicUrl,
       }) + "\\n");
     });
+  }
   }
 }
 `;
@@ -191,7 +202,11 @@ if (runtimeCommand[0] === "true" || runtimeCommand[0] === "test") {
   process.stdin.resume();
   process.stdin.on("end", () => process.stdout.write("Loaded image\\n"));
 } else if (runtimeCommand[0] === "docker" && runtimeCommand[1] === "image" && runtimeCommand[2] === "inspect") {
-  process.stdout.write(process.env.BIMO_TEST_REMOTE_INSPECT + "\\n");
+  if (process.env.BIMO_TEST_IMAGE_MISSING) {
+    process.stderr.write("Error response from daemon: No such image: "
+      + runtimeCommand[runtimeCommand.length - 1] + "\\n");
+    process.exitCode = 1;
+  } else process.stdout.write(process.env.BIMO_TEST_REMOTE_INSPECT + "\\n");
 } else if (runtimeCommand[0] === "docker" && runtimeCommand[1] === "run"
     && runtimeCommand.includes("internal-logs")) {
   process.stdout.write("");
@@ -212,6 +227,10 @@ if (runtimeCommand[0] === "true" || runtimeCommand[0] === "test") {
     if (process.env.BIMO_TEST_CONTROLLER === "conflict") {
       process.stderr.write("Conflict: controller name is already in use\\n");
       process.exitCode = 125;
+    } else if (process.env.BIMO_TEST_CONTROLLER === "publish-resume-missing"
+      && internalCommand === "internal-publish-resume") {
+      process.stderr.write("bimo: no publication-ready record found for run " + envelope.runId + "\\n");
+      process.exitCode = 1;
     } else if (process.env.BIMO_TEST_CONTROLLER === "pod-success" && internalCommand === "internal-pod-run") {
       log({
         tool: "pod-compute-envelope",
@@ -329,6 +348,10 @@ const args = process.argv.slice(2);
 if (args[0] === "--version") process.stdout.write("2.30.0\\n");
 else {
   fs.appendFileSync(process.env.BIMO_TEST_LOG, JSON.stringify({ tool: "op", reference: args[1] }) + "\\n");
+  if (process.env.BIMO_TEST_OP_FAIL) {
+    process.stderr.write("[ERROR] 2026/01/01 00:00:00 You are not currently signed in; run \`op signin\` first\\n");
+    process.exit(1);
+  }
   if (args[1].endsWith("/github")) process.stdout.write("github_pat_${"g".repeat(64)}\\n");
   else process.stdout.write("sk-or-v1-${"k".repeat(32)}\\n");
 }
@@ -336,7 +359,7 @@ else {
   await Promise.all([
     writeFile(path.join(directory, "docker"), docker, { mode: 0o755 }),
     writeFile(path.join(directory, "ssh"), ssh, { mode: 0o755 }),
-    writeFile(path.join(directory, "op"), op, { mode: 0o755 }),
+    ...(missingOp ? [] : [writeFile(path.join(directory, "op"), op, { mode: 0o755 })]),
   ]);
   t.after(() => rm(directory, { recursive: true, force: true }));
 
@@ -623,7 +646,7 @@ test("explicit Proxmox LXC target wraps Docker with pct exec", async t => {
 
   assert.equal(result.code, 0, result.stderr);
   const entries = await readCommandLog(tools.logFile);
-  const invocation = entries.find(entry => entry.tool === "ssh");
+  const invocation = entries.find(entry => entry.tool === "ssh" && entry.command.includes("internal-logs"));
   assert.deepEqual(invocation.command.slice(0, 5), ["pct", "exec", "212", "--", "docker"]);
   assert.ok(invocation.command.includes("internal-logs"));
 });
@@ -719,7 +742,7 @@ test("organize transfers content-verified image without retagging and runs one e
   const remoteRun = remoteCommands.find(command => command[0] === "docker" && command[1] === "run");
   const hostRoot = "/var/lib/bimo/deployments/organizer-demo";
   assert.deepEqual(remoteRun, [
-    "docker", "run", "--rm", "-i",
+    "docker", "run", "--pull=never", "--rm", "-i",
     "--name", "bimo-organizer-demo-controller",
     "--user", "0:0",
     "--read-only",
@@ -997,7 +1020,7 @@ test("deploy rejects image shell syntax before local execution", async () => {
   }
 });
 
-test("deploy rejects changed transferred image content before remote retag or secret resolution", async t => {
+test("deploy rejects changed transferred image content before remote retag", async t => {
   const cases = [
     ["RootFS", { remoteLayers: [`sha256:${"e".repeat(64)}`] }],
     ["Config", { remoteConfig: { ...BASE_CONFIG, Cmd: ["changed-command"] } }],
@@ -1018,7 +1041,9 @@ test("deploy rejects changed transferred image content before remote retag or se
       assert.ok(remoteCommands.some(command => command[0] === "docker" && command[1] === "image" && command[2] === "inspect"));
       assert.equal(remoteCommands.some(command => command[0] === "docker" && command[1] === "image" && command[2] === "tag"), false);
       assert.equal(remoteCommands.some(command => command[0] === "docker" && command[1] === "run"), false);
-      assert.equal(commands.some(entry => entry.tool === "op"), false);
+      const opIndex = commands.findIndex(entry => entry.tool === "op");
+      const buildIndex = commands.findIndex(entry => entry.tool === "docker" && entry.args[0] === "build");
+      assert.ok(opIndex >= 0 && buildIndex >= 0 && opIndex < buildIndex);
       assert.ok(remoteCommands.some(command => command.join(" ") === `docker image rm -f ${transferTag}`));
       assert.ok(localCommands.some(command => command.join(" ") === `image rm -f ${transferTag}`));
     });
@@ -1131,11 +1156,13 @@ test("pod deploy computes without GitHub authority then publishes one exact draf
   assert.equal(publishEnvelope.candidateSha, POD_CANDIDATE_SHA);
 
   const openRouterIndex = entries.findIndex(entry => entry.tool === "op" && entry.reference.endsWith("/openrouter"));
-  const computeIndex = entries.indexOf(computeEnvelope);
   const githubIndex = entries.findIndex(entry => entry.tool === "op" && entry.reference.endsWith("/github"));
+  const buildIndex = entries.findIndex(entry => entry.tool === "docker" && entry.args[0] === "build");
+  const computeIndex = entries.indexOf(computeEnvelope);
   const publishIndex = entries.indexOf(publishEnvelope);
-  assert.ok(openRouterIndex >= 0 && openRouterIndex < computeIndex);
-  assert.ok(computeIndex < githubIndex && githubIndex < publishIndex);
+  assert.ok(openRouterIndex >= 0 && githubIndex >= 0 && buildIndex >= 0);
+  assert.ok(openRouterIndex < buildIndex && githubIndex < buildIndex);
+  assert.ok(buildIndex < computeIndex && computeIndex < publishIndex);
   const serializedLog = JSON.stringify(entries);
   assert.equal(serializedLog.includes(`sk-or-v1-${"k".repeat(32)}`), false);
   assert.equal(serializedLog.includes(`github_pat_${"g".repeat(64)}`), false);
@@ -1921,7 +1948,7 @@ test("internal-publish-resume fails closed without durable publication evidence"
     input: resumeEnvelope(runId),
   });
   assert.equal(result.code, 1);
-  assert.match(result.stderr, /run has no unique publication\.ready record/);
+  assert.match(result.stderr, new RegExp(`no publication-ready record found for run ${runId}`));
 
   for (const [input, pattern] of [
     [{ version: 1, runId, token: "not-a-token" }, /publisher resume envelope is invalid/],
@@ -1944,4 +1971,222 @@ test("help covers the cancel and publish commands", async () => {
   const usageText = await invoke(["help"]);
   assert.match(usageText.stdout, /^ {2}bimo cancel --deployment NAME/m);
   assert.match(usageText.stdout, /^ {2}bimo publish --deployment NAME/m);
+});
+
+test("read containers pass --pull=never and preflight image presence before running", async t => {
+  const tools = await fakeDeployTools(t);
+  const runsPayload = `${JSON.stringify({ deployment: "fleet-demo", runs: [] })}\n`;
+  const result = await invoke([
+    "runs", "--deployment", "fleet-demo", "--host", "example.invalid",
+    "--image", "bimo-workflow:test", "--json",
+  ], { env: { ...tools.env, BIMO_TEST_RUNS_OUTPUT: runsPayload } });
+  assert.equal(result.code, 0, result.stderr);
+
+  const commands = (await readCommandLog(tools.logFile))
+    .filter(entry => entry.tool === "ssh")
+    .map(entry => entry.command);
+  const inspect = commands.find(command => (
+    command[0] === "docker" && command[1] === "image" && command[2] === "inspect"
+  ));
+  const read = commands.find(command => command.includes("internal-runs"));
+  assert.ok(inspect, "image-presence preflight did not run");
+  assert.ok(read.includes("--pull=never"));
+  assert.ok(commands.indexOf(inspect) < commands.indexOf(read));
+});
+
+test("every docker run the CLI builds is pinned with --pull=never", async t => {
+  const tools = await fakeDeployTools(t, { controller: "pod-success" });
+  const result = await invoke(podDeployArgs(tools.taskFile), { env: tools.env });
+  assert.equal(result.code, 0, result.stderr);
+
+  const commands = (await readCommandLog(tools.logFile))
+    .filter(entry => entry.tool === "ssh")
+    .map(entry => entry.command);
+  const runs = commands.filter(command => command[0] === "docker" && command[1] === "run");
+  assert.ok(runs.length >= 2, "expected controller and publisher runs");
+  for (const command of runs) {
+    assert.ok(command.includes("--pull=never"), `missing --pull=never: ${command.join(" ")}`);
+  }
+});
+
+test("logs reports a missing image without pulling or leaking the docker-login hint", async t => {
+  const tools = await fakeDeployTools(t);
+  const env = { ...tools.env, BIMO_TEST_IMAGE_MISSING: "1" };
+
+  const remote = await invoke([
+    "logs", "--deployment", "fleet-demo", "--host", "example.invalid", "--image", "bimo-workflow:test",
+  ], { env });
+  assert.equal(remote.code, 1);
+  assert.match(remote.stderr,
+    /bimo image bimo-workflow:test is not built on the target yet; run bimo deploy first/);
+  assert.doesNotMatch(remote.stderr, /docker login|pull access denied/i);
+
+  const follow = await invoke([
+    "logs", "--deployment", "fleet-demo", "--host", "example.invalid",
+    "--image", "bimo-workflow:test", "--follow",
+  ], { env });
+  assert.equal(follow.code, 1);
+  assert.match(follow.stderr, /the run is still preparing its image/);
+  assert.doesNotMatch(follow.stderr, /docker login|pull access denied/i);
+
+  const local = await invoke([
+    "logs", "--deployment", "fleet-demo", "--image", "bimo-workflow:test",
+  ], { env });
+  assert.equal(local.code, 1);
+  assert.match(local.stderr, /bimo image bimo-workflow:test is not built locally yet/);
+  assert.doesNotMatch(local.stderr, /docker login|pull access denied/i);
+
+  const commands = (await readCommandLog(tools.logFile))
+    .filter(entry => entry.tool === "ssh" || entry.tool === "docker");
+  assert.equal(commands.some(entry => {
+    const command = entry.command ?? entry.args;
+    return command.includes("internal-logs") || command.includes("internal-tail");
+  }), false);
+});
+
+test("deploy and organize resolve --secret-ref before any image build", async t => {
+  const deployTools = await fakeDeployTools(t);
+  const deployResult = await invoke(deployArgs(deployTools.taskFile), { env: deployTools.env });
+  assert.equal(deployResult.code, 1);
+  const deployEntries = await readCommandLog(deployTools.logFile);
+  const deployOp = deployEntries.findIndex(entry => entry.tool === "op");
+  const deployBuild = deployEntries.findIndex(entry => (
+    entry.tool === "docker" && entry.args[0] === "build"
+  ));
+  assert.ok(deployOp >= 0 && deployBuild >= 0 && deployOp < deployBuild);
+
+  const organizeTools = await fakeDeployTools(t, { controller: "organize-success" });
+  const organizeResult = await invoke(organizeArgs("Build a small status page."), {
+    env: organizeTools.env,
+  });
+  assert.equal(organizeResult.code, 0, organizeResult.stderr);
+  const organizeEntries = await readCommandLog(organizeTools.logFile);
+  const organizeOp = organizeEntries.findIndex(entry => entry.tool === "op");
+  const organizeBuild = organizeEntries.findIndex(entry => (
+    entry.tool === "docker" && entry.args[0] === "build"
+  ));
+  assert.ok(organizeOp >= 0 && organizeBuild >= 0 && organizeOp < organizeBuild);
+});
+
+test("deploy, organize, and publish report a missing 1Password CLI before any Docker work", async t => {
+  const tools = await fakeDeployTools(t, { missingOp: true });
+  const env = {
+    ...tools.env,
+    PATH: `${path.dirname(tools.taskFile)}${path.delimiter}/usr/bin${path.delimiter}/bin`,
+  };
+
+  const deployResult = await invoke(deployArgs(tools.taskFile), { env });
+  assert.equal(deployResult.code, 1);
+  assert.match(deployResult.stderr,
+    /1Password CLI \(`op`\) not found; it is required to resolve --secret-ref/);
+  assert.match(deployResult.stderr, /1password\.com/);
+  assert.doesNotMatch(deployResult.stderr, /ENOENT/);
+
+  const organizeResult = await invoke(organizeArgs("Build a small status page."), { env });
+  assert.equal(organizeResult.code, 1);
+  assert.match(organizeResult.stderr,
+    /1Password CLI \(`op`\) not found; it is required to resolve --secret-ref/);
+
+  const publishResult = await invoke([
+    "publish", "--deployment", "pod-demo", "--host", "example.invalid",
+    "--github-secret-ref", "op://Test/Bimo publisher/github", "--image", "bimo-workflow:test",
+  ], { env });
+  assert.equal(publishResult.code, 1);
+  assert.match(publishResult.stderr,
+    /1Password CLI \(`op`\) not found; it is required to resolve --github-secret-ref/);
+
+  const entries = await readCommandLog(tools.logFile);
+  assert.equal(entries.some(entry => entry.tool === "docker" || entry.tool === "ssh"), false);
+});
+
+test("doctor reports a missing 1Password CLI as a bounded check failure", async t => {
+  const tools = await fakeDeployTools(t, { missingOp: true });
+  const env = {
+    ...tools.env,
+    PATH: `${path.dirname(tools.taskFile)}${path.delimiter}/usr/bin${path.delimiter}/bin`,
+  };
+  const result = await invoke(["doctor", "--secret-ref", "op://Test/Bimo/key", "--json"], { env });
+  assert.equal(result.code, 1);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.ok, false);
+  const opCheck = report.checks.find(check => check.name === "op-cli");
+  assert.equal(opCheck.status, "fail");
+  assert.match(opCheck.reason, /1Password CLI \(`op`\) not found/);
+  assert.doesNotMatch(opCheck.reason, /ENOENT/);
+  assert.equal(report.checks.find(check => check.name === "secret-ref").status, "skip");
+});
+
+test("an unauthenticated 1Password CLI keeps its guidance under one bimo framing line", async t => {
+  const tools = await fakeDeployTools(t);
+  const result = await invoke(deployArgs(tools.taskFile), {
+    env: { ...tools.env, BIMO_TEST_OP_FAIL: "1" },
+  });
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /^bimo: failed to resolve --secret-ref via 1Password: /);
+  assert.match(result.stderr, /op signin/);
+  const entries = await readCommandLog(tools.logFile);
+  assert.equal(entries.some(entry => entry.tool === "docker" && entry.args[0] === "build"), false);
+});
+
+test("internal-logs prints a friendly empty state when no runs are recorded", async t => {
+  const directory = await mkdtemp(path.join(tmpdir(), "bimo-state-empty-"));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+
+  const text = await invoke(["internal-logs", "--state-root", directory, "--deployment", "demo"]);
+  assert.equal(text.code, 0, text.stderr);
+  assert.equal(text.stdout, "no runs recorded for deployment demo\n");
+  assert.equal(text.stderr, "");
+
+  const json = await invoke([
+    "internal-logs", "--state-root", directory, "--deployment", "demo", "--json",
+  ]);
+  assert.equal(json.code, 0, json.stderr);
+  assert.deepEqual(JSON.parse(json.stdout), { deployment: "demo", run: null, events: [] });
+});
+
+test("nested docker error prefixes collapse to one bimo prefix per boundary", async t => {
+  const tools = await fakeDeployTools(t);
+  const payload = "bimo: docker exited 1: bimo-agent: agent exited 1; errorStatus=401";
+  const result = await invoke([
+    "logs", "--deployment", "fleet-demo", "--image", "bimo-workflow:test", "--json",
+  ], { env: { ...tools.env, BIMO_TEST_READ_FAIL: payload } });
+  assert.equal(result.code, 1);
+  assert.equal(
+    result.stderr,
+    `bimo: docker exited 1: ${payload.slice("bimo: ".length)}\n`,
+  );
+  const receipt = JSON.parse(result.stdout);
+  assert.equal(receipt.ok, false);
+  assert.equal(receipt.error.command, "logs");
+  assert.equal(receipt.error.message, `docker exited 1: ${payload.slice("bimo: ".length)}`);
+});
+
+test("publish --json reports a run without a publication-ready record as a structured failure", async t => {
+  const tools = await fakeDeployTools(t, { controller: "publish-resume-missing" });
+  const runId = "20240101000000-abcd1234";
+  const result = await invoke([
+    "publish", "--deployment", "pod-demo", "--run", runId,
+    "--host", "example.invalid",
+    "--github-secret-ref", "op://Test/Bimo publisher/github",
+    "--image", "bimo-workflow:test", "--json",
+  ], { env: tools.env });
+  assert.equal(result.code, 1);
+  const receipt = JSON.parse(result.stdout);
+  assert.equal(receipt.ok, false);
+  assert.equal(receipt.error.command, "publish");
+  assert.equal(receipt.error.message, `ssh exited 1: no publication-ready record found for run ${runId}`);
+  assert.equal(
+    result.stderr,
+    `bimo: ssh exited 1: no publication-ready record found for run ${runId}\n`,
+  );
+});
+
+test("internal-publish-resume names the run when no publication-ready record exists", async t => {
+  const { directory } = await fakePublicationStore(t, { ready: false });
+  const missing = await invoke(["internal-publish-resume", "--state-root", directory], {
+    input: resumeEnvelope("20240909000000-ffff9999"),
+  });
+  assert.equal(missing.code, 1);
+  assert.match(missing.stderr,
+    /no publication-ready record found for run 20240909000000-ffff9999/);
 });

--- a/test/docker-runtime.test.mjs
+++ b/test/docker-runtime.test.mjs
@@ -203,6 +203,51 @@ test("only Engineering receives a writable shared workspace", () => {
   assert.doesNotMatch(args.join(" "), /dst=\/workspace,readonly/);
 });
 
+test("every container run or create is pinned to the local image with --pull=never", () => {
+  const receipt = { files: 12, bytes: 4_096, sha256: "c".repeat(64) };
+  const cases = [
+    bootstrapArgs({ ...common, workspaceHost: "/var/lib/bimo/deployments/demo/workspace" }),
+    proxyCreateArgs({
+      ...common,
+      network: "bimo-demo-agents",
+      model: "openrouter/deepseek/deepseek-v4-flash",
+    }),
+    agentCreateArgs({
+      ...common,
+      role: "qa",
+      step: 2,
+      network: "bimo-demo-agents",
+      workspaceHost: "/var/lib/bimo/deployments/demo/workspace",
+      handoffHost: "/var/lib/bimo/deployments/demo/runs/run-1/attempts/qa/handoff",
+      promptHost: "/var/lib/bimo/deployments/demo/runs/run-1/attempts/qa/instructions.md",
+      access: "read",
+      model: "openrouter/deepseek/deepseek-v4-flash",
+      timeoutSeconds: 1200,
+    }),
+    serverCreateArgs({
+      ...common,
+      outputHost: "/var/lib/bimo/deployments/demo/runs/run-1/artifact",
+      port: 8080,
+    }),
+    sourceVerifierCreateArgs({
+      deployment: "demo",
+      hostRoot: "/var/lib/bimo/deployments/demo",
+      image: IMAGE,
+      snapshotHost: "/var/lib/bimo/deployments/demo/snapshots/run-1/candidate-1",
+      expectedSha: "d".repeat(40),
+      expectedSnapshot: receipt,
+      profile: "bimo-repo-v1",
+      suite: "candidate",
+      timeoutSeconds: 300,
+      nameSuffix: "source-candidate",
+    }),
+  ];
+  for (const args of cases) {
+    assert.ok(["run", "create"].includes(args[0]));
+    assert.equal(args[1], "--pull=never");
+  }
+});
+
 test("bootstrap is fixed, offline, and receives only the writable workspace", () => {
   const args = bootstrapArgs({
     ...common,
@@ -210,7 +255,7 @@ test("bootstrap is fixed, offline, and receives only the writable workspace", ()
   });
   const rendered = args.join(" ");
 
-  assert.deepEqual(args.slice(0, 4), ["run", "--rm", "--name", "bimo-demo-bootstrap"]);
+  assert.deepEqual(args.slice(0, 4), ["run", "--pull=never", "--rm", "--name"]);
   assert.match(rendered, /--label dev\.ascii\.bimo\.deployment=demo/);
   assert.match(rendered, /--label dev\.ascii\.bimo\.transient=true/);
   assert.match(rendered, /--network none --read-only/);
@@ -262,8 +307,8 @@ test("start bootstraps offline, creates two networks, and dual-homes only the pr
   const networkConnect = calls.find(args => args[0] === "network" && args[1] === "connect");
   const readinessProbe = calls.find(args => args[0] === "run" && args.includes("probe"));
   assert.deepEqual(bootstrap.slice(0, 4), [
-    "run", "--rm", "--name", "bimo-demo-bootstrap", "--network", "none",
-  ].slice(0, 4));
+    "run", "--pull=never", "--rm", "--name",
+  ]);
   assert(agentNetwork.includes("bimo-demo-agents"));
   assert(egressNetwork.includes("bimo-demo-egress"));
   assert.equal(proxyCreate[proxyCreate.indexOf("--network") + 1], "bimo-demo-agents");


### PR DESCRIPTION
Closes #29
Closes #30
Closes #31

## Root causes and fixes

**#29 — implicit pull of `bimo-workflow` from the read path**
- Root cause: read containers (`logs`/`runs`/`status`/`cancel`/`publish`) ran `docker run` without `--pull=never`, so a missing local image made Docker attempt a pull of `bimo-workflow` — breaking the runtime-contract invariant "never pulls a mutable reference at run time" and surfacing the misleading `docker login` hint.
- Fix: every `docker run`/`docker create` the CLI and `DockerRuntime` build is pinned with `--pull=never`; read paths preflight local image presence (`requireImagePresent`) and fail closed with `bimo image bimo-workflow:0.5.0 is not built locally yet; run bimo deploy first`. Under `logs --follow` the message instead says the run is still preparing its image. Daemon errors other than `No such image` still surface verbatim.

**#30 — missing/unauthenticated `op` and secret-vs-build ordering**
- Root cause: `op` spawn errors leaked the raw node errno (`spawn op ENOENT`), and deploy/organize resolved secrets only *after* the ~30s image build.
- Fix: one `opRead` helper used by deploy/organize/publish/doctor — missing CLI fails with `1Password CLI (`op`) not found; it is required to resolve --secret-ref` plus an install link; an unauthenticated CLI keeps op's guidance under one framing line (`failed to resolve --secret-ref via 1Password: ...`). Secret resolution now happens before any image build/transfer work in every flow, and tests pin op-before-build ordering.

**#31 — cryptic empty-state and nested error messages**
- `bimo logs --deployment X` with no runs now prints `no runs recorded for deployment X` and exits 0 (matching `runs` on the empty case); `--json` returns `{deployment, run: null, events: []}`.
- Nested prefixes like `bimo: docker exited 1: bimo: docker exited 1: bimo-agent: ...` collapse at each tool boundary to a single `bimo: ` layer (payload preserved verbatim), in both stderr and `--json` error receipts.
- `publish` on a run without a `publication.ready` record now fails closed with `no publication-ready record found for run <id>` instead of `run record is invalid`; the structured `--json` failure shape is unchanged.

## Verification
- `npm test`: 259 passing (247 on main + 12 new), `node --check src/bimo.mjs` clean.
- New tests cover: --pull=never on every built run/create argv, image-presence preflight and its messages (plain/follow/local), op-before-build ordering, missing `op` for deploy/organize/publish/doctor, unauthenticated `op` framing, empty-logs exit code and shapes, prefix collapse, and the publish no-record message.