### PR TITLE
Fix alpha dogfood wave B: honest run IDs, state hygiene, CLI discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,11 @@ stdout while the human message stays on stderr.
 
 `cancel` sends SIGTERM to the deployment's running controller (or publisher)
 container on the target; the in-container controller cancels active work and
-finishes the run durably. `publish` resumes an interrupted pod publication
+finishes the run durably. Interrupting the CLI itself with Ctrl+C does not
+cancel the run: the CLI prints a detach notice, exits 130, and the run
+continues on the target — use `cancel` to stop it. A cancelled run finishes
+as `failed` with reason `deployment cancelled`; there is no distinct
+`cancelled` state. `publish` resumes an interrupted pod publication
 from the durable `publication.ready` record — replaying an already completed
 publication returns its receipt with zero new side effects.
 

--- a/src/bimo.mjs
+++ b/src/bimo.mjs
@@ -8,6 +8,7 @@ import {
   open,
   readFile,
   readdir,
+  rmdir,
 } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
@@ -65,6 +66,20 @@ const POD_DEPLOY_OPTIONS = [
   "--deployment", "--target", "--host", "--proxmox", "--vmid", "--task-file", "--task-stdin",
   "--secret-ref", "--github-secret-ref", "--repository", "--base-sha", "--target-branch",
 ];
+const ORGANIZE_OPTIONS = [
+  "prompt", "agents", "deployment", "target", "proxmox", "host", "vmid",
+  "secret-ref", "account", "model", "image", "json",
+];
+const DEPLOY_WORKFLOW_OPTIONS = [
+  "deployment", "target", "proxmox", "host", "vmid", "task-file", "task-stdin",
+  "secret-ref", "account", "public-url", "port", "model", "image", "json",
+];
+const DEPLOY_POD_OPTIONS = [
+  "deployment", "target", "proxmox", "host", "vmid", "task-file", "task-stdin",
+  "secret-ref", "github-secret-ref", "account", "repository", "base-sha",
+  "target-branch", "model", "image", "json",
+];
+const DEPLOY_OPTIONS = [...new Set([...DEPLOY_WORKFLOW_OPTIONS, ...DEPLOY_POD_OPTIONS])];
 const DEPLOYMENT_LAYOUTS = {
   workflow: ["runs", "workspace"],
   organizer: ["runs", "worktrees"],
@@ -83,7 +98,7 @@ function fail(message) {
   throw new Error(message);
 }
 
-function parseOptions(argv, { booleans = [] } = {}) {
+function parseOptions(argv, { booleans = [], allowed } = {}) {
   const options = {};
   const positional = [];
   for (let index = 0; index < argv.length; index += 1) {
@@ -94,6 +109,7 @@ function parseOptions(argv, { booleans = [] } = {}) {
     }
     const key = value.slice(2);
     if (Object.hasOwn(options, key)) fail(`duplicate option: --${key}`);
+    if (allowed && !allowed.includes(key)) fail(`unknown option: --${key}`);
     if (booleans.includes(key)) options[key] = true;
     else {
       const next = argv[index + 1];
@@ -108,6 +124,7 @@ function parseOptions(argv, { booleans = [] } = {}) {
 function parseOrganizerOptions(argv) {
   const options = {};
   const positional = [];
+  let agentFlag = "--agents";
   for (let index = 0; index < argv.length; index += 1) {
     const value = argv[index];
     const option = value === "-p" ? "--prompt" : value === "-n" ? "--agents" : value;
@@ -117,15 +134,17 @@ function parseOrganizerOptions(argv) {
     }
     const key = option.slice(2);
     if (Object.hasOwn(options, key)) fail(`duplicate option: --${key}`);
+    if (!ORGANIZE_OPTIONS.includes(key)) fail(`unknown option: --${key}`);
     if (key === "json") options[key] = true;
     else {
       const next = argv[index + 1];
       if (next === undefined) fail(`--${key} requires a value`);
       options[key] = next;
+      if (key === "agents") agentFlag = value;
       index += 1;
     }
   }
-  return { positional, options };
+  return { positional, options, agentFlag };
 }
 
 function exactOptions(options, allowed) {
@@ -646,6 +665,44 @@ async function prepareDeploymentState(target, image, hostRoot, layout) {
   }
 }
 
+// Best-effort cleanup after a run that failed before recording anything:
+// rmdir removes only empty directories, so recorded state is never touched.
+async function reapDeploymentState(target, hostRoot, layout) {
+  const directories = deploymentDirectories(layout).map(directory => `${hostRoot}/${directory}`);
+  if (target.kind === "local") {
+    for (const directory of [...directories, hostRoot]) {
+      await rmdir(directory).catch(() => {});
+    }
+    return;
+  }
+  await targetExecute(target, ["rmdir", ...directories, hostRoot], {
+    timeoutMs: 15_000,
+    maxOutputBytes: 4 * 1024,
+  }).catch(() => {});
+}
+
+// Read paths must not let Docker auto-create the bind-mounted state root.
+async function deploymentRunsExist(target, hostRoot) {
+  if (target.kind === "local") {
+    const stat = await lstat(path.join(hostRoot, "runs")).catch(() => null);
+    return Boolean(stat?.isDirectory() && !stat.isSymbolicLink());
+  }
+  return targetExecute(target, ["test", "-d", `${hostRoot}/runs`], {
+    timeoutMs: 15_000,
+    maxOutputBytes: 4 * 1024,
+  }).then(() => true, () => false);
+}
+
+// SIGINT detaches the CLI; the controller keeps running on the target.
+function armDetachNotice(deployment) {
+  const detach = () => {
+    process.stderr.write(`detaching; the run continues on the target — use bimo cancel --deployment ${deployment} to stop it\n`);
+    process.exit(130);
+  };
+  process.once("SIGINT", detach);
+  return () => process.off("SIGINT", detach);
+}
+
 function isPlainObject(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value)
     && Object.getPrototypeOf(value) === Object.prototype;
@@ -823,14 +880,7 @@ async function resolveGitHubSecret(reference, account) {
 async function deploy(template, options) {
   const loaded = await loadTemplate(template);
   const pod = loaded.kind === "engineering-pod";
-  exactOptions(options, pod ? [
-    "deployment", "target", "proxmox", "host", "vmid", "task-file", "task-stdin",
-    "secret-ref", "github-secret-ref", "account", "repository", "base-sha",
-    "target-branch", "model", "image", "json",
-  ] : [
-    "deployment", "target", "proxmox", "host", "vmid", "task-file", "task-stdin",
-    "secret-ref", "account", "public-url", "port", "model", "image", "json",
-  ]);
+  exactOptions(options, pod ? DEPLOY_POD_OPTIONS : DEPLOY_WORKFLOW_OPTIONS);
   if (!options.deployment) fail("--deployment is required");
   if (!NAME.test(options.deployment)) fail("--deployment must use lowercase letters, numbers, and dashes");
   const deploymentTarget = resolveDeploymentTarget(options);
@@ -861,10 +911,12 @@ async function deploy(template, options) {
 
   const runId = `${new Date().toISOString().replace(/[-:.TZ]/g, "").slice(0, 14)}-${randomUUID().slice(0, 8)}`;
   const progress = options.json ? null : new AbortController();
-  if (progress) process.stderr.write(`run: ${runId}\n`);
   const heartbeat = progress ? startRunHeartbeat({ runId }) : null;
+  const hostRoot = deploymentRootForTarget(deploymentTarget, options.deployment);
+  const disarmDetachNotice = armDetachNotice(options.deployment);
   let follower = null;
   let transferTag = null;
+  let stateLayout = null;
   try {
     let openRouterKey = await resolveSecret(options["secret-ref"], options.account);
     let githubToken = pod
@@ -874,7 +926,6 @@ async function deploy(template, options) {
     const prepared = await prepareImage(deploymentTarget, image);
     const remoteImage = prepared.remoteImage;
     transferTag = prepared.transferTag;
-    const hostRoot = deploymentRootForTarget(deploymentTarget, options.deployment);
     if (progress) {
       heartbeat.setPhase("running controller");
       const readChunk = async ({ runId: current, after, signal }) => {
@@ -893,7 +944,9 @@ async function deploy(template, options) {
       }).catch(() => {});
     }
     if (pod) {
+      stateLayout = "pod";
       await prepareDeploymentState(deploymentTarget, remoteImage.imageId, hostRoot, "pod");
+      if (progress) process.stderr.write(`run: ${runId}\n`);
       const computeEnvelope = JSON.stringify({
         version: 1,
         template: loaded.template.name,
@@ -980,7 +1033,9 @@ async function deploy(template, options) {
         `deployed ${loaded.template.name} as ${options.deployment}\nrun: ${response.runId}\nPR: ${response.publication.url} (draft)\n`,
       );
     } else {
+      stateLayout = "workflow";
       await prepareDeploymentState(deploymentTarget, remoteImage.imageId, hostRoot, "workflow");
+      if (progress) process.stderr.write(`run: ${runId}\n`);
 
       const envelope = JSON.stringify({
         version: 1,
@@ -1023,7 +1078,11 @@ async function deploy(template, options) {
       if (options.json) process.stdout.write(`${JSON.stringify(response)}\n`);
       else process.stdout.write(`deployed ${response.template} as ${response.deployment}\nrun: ${response.runId}\nurl: ${response.url}\n`);
     }
+  } catch (error) {
+    if (stateLayout) await reapDeploymentState(deploymentTarget, hostRoot, stateLayout);
+    throw error;
   } finally {
+    disarmDetachNotice();
     progress?.abort();
     if (follower) await follower;
     heartbeat?.stop();
@@ -1031,11 +1090,8 @@ async function deploy(template, options) {
   }
 }
 
-async function organizeRemote(options) {
-  exactOptions(options, [
-    "prompt", "agents", "deployment", "target", "proxmox", "host", "vmid",
-    "secret-ref", "account", "model", "image", "json",
-  ]);
+async function organizeRemote(options, agentFlag = "--agents") {
+  exactOptions(options, ORGANIZE_OPTIONS);
   if (!options.deployment) fail("--deployment is required");
   if (!NAME.test(options.deployment)) {
     fail("--deployment must use lowercase letters, numbers, and dashes");
@@ -1043,7 +1099,7 @@ async function organizeRemote(options) {
   const deploymentTarget = resolveDeploymentTarget(options);
   const prompt = validateOrganizerPrompt(options.prompt);
   const agentsText = options.agents ?? "1";
-  if (!/^[1-3]$/u.test(agentsText)) fail("--agents must be an integer from 1 to 3");
+  if (!/^[1-3]$/u.test(agentsText)) fail(`${agentFlag} must be an integer from 1 to 3`);
   const agents = Number(agentsText);
   if (!options["secret-ref"]) fail("--secret-ref is required");
   const image = options.image ?? DEFAULT_IMAGE;
@@ -1055,17 +1111,18 @@ async function organizeRemote(options) {
 
   const runId = `${new Date().toISOString().replace(/[-:.TZ]/g, "").slice(0, 14)}-${randomUUID().slice(0, 8)}`;
   const progress = options.json ? null : new AbortController();
-  if (progress) process.stderr.write(`run: ${runId}\n`);
   const heartbeat = progress ? startRunHeartbeat({ runId }) : null;
+  const hostRoot = deploymentRootForTarget(deploymentTarget, options.deployment);
+  const disarmDetachNotice = armDetachNotice(options.deployment);
   let follower = null;
   let transferTag = null;
+  let stateLayout = null;
   try {
     let openRouterKey = await resolveSecret(options["secret-ref"], options.account);
     heartbeat?.setPhase("preparing image");
     const prepared = await prepareImage(deploymentTarget, image, { retag: false });
     const remoteImage = prepared.remoteImage;
     transferTag = prepared.transferTag;
-    const hostRoot = deploymentRootForTarget(deploymentTarget, options.deployment);
     if (progress) {
       heartbeat.setPhase("running controller");
       const readChunk = async ({ runId: current, after, signal }) => {
@@ -1083,7 +1140,9 @@ async function organizeRemote(options) {
         },
       }).catch(() => {});
     }
+    stateLayout = "organizer";
     await prepareDeploymentState(deploymentTarget, remoteImage.imageId, hostRoot, "organizer");
+    if (progress) process.stderr.write(`run: ${runId}\n`);
     const envelope = JSON.stringify({
       version: 1,
       deployment: options.deployment,
@@ -1133,7 +1192,11 @@ async function organizeRemote(options) {
       `accepted deploy options: ${response.handoff.acceptedOptions.join(", ")}`,
       "",
     ].join("\n"));
+  } catch (error) {
+    if (stateLayout) await reapDeploymentState(deploymentTarget, hostRoot, stateLayout);
+    throw error;
   } finally {
+    disarmDetachNotice();
     progress?.abort();
     if (follower) await follower;
     heartbeat?.stop();
@@ -1645,6 +1708,15 @@ async function remoteLogs(options) {
   if (!IMAGE.test(image)) fail("--image is invalid");
   const hostRoot = deploymentRootForTarget(deploymentTarget, options.deployment);
   await requireImagePresent(deploymentTarget, image, { preparing: Boolean(options.follow) });
+  if (!await deploymentRunsExist(deploymentTarget, hostRoot)) {
+    if (options.run) fail(`unknown run: ${runId}`);
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify({ deployment: options.deployment, run: null, events: [] })}\n`);
+    } else {
+      process.stdout.write(`no runs recorded for deployment ${options.deployment}\n`);
+    }
+    return;
+  }
   if (options.follow) {
     await followLogs(deploymentTarget, { hostRoot, image, runId, json: Boolean(options.json) });
     return;
@@ -1792,7 +1864,7 @@ async function summarizeRun(stateRoot, runId, { withLastEvent = false } = {}) {
   const phase = typeof record?.phase === "string" && record.phase.length <= 64 ? record.phase : null;
 
   let events = [];
-  if (!state) events = await readRunEvents(runDir, { wholeFile: true });
+  if (!state || attempts === null) events = await readRunEvents(runDir, { wholeFile: true });
   else if (withLastEvent) events = await readRunEvents(runDir, { wholeFile: false });
 
   if (!state) {
@@ -1809,7 +1881,15 @@ async function summarizeRun(stateRoot, runId, { withLastEvent = false } = {}) {
       0,
     );
   }
-  if (attempts === null) attempts = events.length ? 1 : 0;
+  if (attempts === null) {
+    // run.json recorded a state but no currentAttempt (organizer runs); derive
+    // attempts from the event log so runs and status agree on one value.
+    const derived = events.reduce(
+      (maximum, event) => (Number.isSafeInteger(event.attempt) ? Math.max(maximum, event.attempt) : maximum),
+      0,
+    );
+    attempts = derived > 0 ? derived : (events.length ? 1 : 0);
+  }
 
   return {
     id: runId,
@@ -1860,6 +1940,26 @@ async function internalRuns(argv) {
   }
 }
 
+function writeStatusPayload(payload, { json }) {
+  if (json) {
+    process.stdout.write(`${JSON.stringify(payload)}\n`);
+    return;
+  }
+  const lines = [
+    `deployment: ${payload.deployment}`,
+    `run: ${payload.runId ?? "-"}`,
+    `state: ${payload.state}`,
+  ];
+  if (payload.phase) lines.push(`phase: ${payload.phase}`);
+  lines.push(`started: ${payload.startedAt ?? "-"}`);
+  lines.push(`finished: ${payload.finishedAt ?? "-"}`);
+  lines.push(`attempts: ${payload.attempts}`);
+  if (payload.lastEvent) {
+    lines.push(`last event: ${payload.lastEvent.type ?? "event"} at ${payload.lastEvent.timestamp ?? "-"}`);
+  }
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
 async function internalStatus(argv) {
   const { positional, options } = parseOptions(argv, { booleans: ["json"] });
   if (positional.length) fail("internal-status accepts no positional arguments");
@@ -1888,24 +1988,7 @@ async function internalStatus(argv) {
     const { id, ...rest } = summary;
     status = { runId: id, ...rest };
   }
-  const payload = { deployment: options.deployment, ...status };
-  if (options.json) {
-    process.stdout.write(`${JSON.stringify(payload)}\n`);
-    return;
-  }
-  const lines = [
-    `deployment: ${payload.deployment}`,
-    `run: ${payload.runId ?? "-"}`,
-    `state: ${payload.state}`,
-  ];
-  if (payload.phase) lines.push(`phase: ${payload.phase}`);
-  lines.push(`started: ${payload.startedAt ?? "-"}`);
-  lines.push(`finished: ${payload.finishedAt ?? "-"}`);
-  lines.push(`attempts: ${payload.attempts}`);
-  if (payload.lastEvent) {
-    lines.push(`last event: ${payload.lastEvent.type ?? "event"} at ${payload.lastEvent.timestamp ?? "-"}`);
-  }
-  process.stdout.write(`${lines.join("\n")}\n`);
+  writeStatusPayload({ deployment: options.deployment, ...status }, { json: Boolean(options.json) });
 }
 
 async function internalTail(argv) {
@@ -1967,6 +2050,12 @@ async function remoteRuns(options) {
   if (!IMAGE.test(image)) fail("--image is invalid");
   const hostRoot = deploymentRootForTarget(deploymentTarget, options.deployment);
   await requireImagePresent(deploymentTarget, image);
+  if (!await deploymentRunsExist(deploymentTarget, hostRoot)) {
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify({ deployment: options.deployment, runs: [] })}\n`);
+    }
+    return;
+  }
   const result = await targetExecute(deploymentTarget, stateReadArgs(hostRoot, image, [
     "internal-runs",
     "--deployment", options.deployment,
@@ -1986,6 +2075,20 @@ async function remoteStatus(options) {
   if (!IMAGE.test(image)) fail("--image is invalid");
   const hostRoot = deploymentRootForTarget(deploymentTarget, options.deployment);
   await requireImagePresent(deploymentTarget, image);
+  if (!await deploymentRunsExist(deploymentTarget, hostRoot)) {
+    if (options.run) fail(`unknown run: ${runId}`);
+    writeStatusPayload({
+      deployment: options.deployment,
+      runId: null,
+      state: "none",
+      phase: null,
+      startedAt: null,
+      finishedAt: null,
+      attempts: 0,
+      lastEvent: null,
+    }, { json: Boolean(options.json) });
+    return;
+  }
   const result = await targetExecute(deploymentTarget, stateReadArgs(hostRoot, image, [
     "internal-status",
     "--deployment", options.deployment,
@@ -2007,6 +2110,7 @@ async function remoteCancel(options) {
   const hostRoot = deploymentRootForTarget(deploymentTarget, options.deployment);
   if (runId !== null) {
     await requireImagePresent(deploymentTarget, image);
+    if (!await deploymentRunsExist(deploymentTarget, hostRoot)) fail(`unknown run: ${runId}`);
     const statusResult = await targetExecute(deploymentTarget, stateReadArgs(hostRoot, image, [
       "internal-status",
       "--deployment", options.deployment,
@@ -2036,7 +2140,7 @@ async function remoteCancel(options) {
     return;
   }
   for (const name of signalled) {
-    process.stdout.write(`sent SIGTERM to ${name}; the run will finish as failed or cancelled\n`);
+    process.stdout.write(`sent SIGTERM to ${name}; the run will finish as failed with reason 'deployment cancelled'\n`);
   }
 }
 
@@ -2083,29 +2187,39 @@ async function remotePublish(options) {
   const hostRoot = deploymentRootForTarget(deploymentTarget, options.deployment);
   let githubToken = await resolveGitHubSecret(options["github-secret-ref"], options.account);
   await requireImagePresent(deploymentTarget, image);
+  if (!await deploymentRunsExist(deploymentTarget, hostRoot)) {
+    if (!options.run) fail("no latest run is recorded");
+    fail(`no publication-ready record found for run ${runId}`);
+  }
   const envelope = JSON.stringify({ version: 1, runId, token: githubToken });
   githubToken = "";
-  const publisher = await targetExecute(deploymentTarget, [
-    "docker", "run", "--pull=never", "--rm", "-i",
-    "--name", `bimo-${options.deployment}-publisher`,
-    "--user", "0:0",
-    "--read-only",
-    "--cap-drop", "ALL",
-    "--security-opt", "no-new-privileges",
-    "--pids-limit", "128",
-    "--memory", "512m",
-    "--cpus", "0.5",
-    "--tmpfs", "/tmp:rw,nosuid,nodev,noexec,size=32m",
-    "--tmpfs", "/run/bimo-publish:rw,nosuid,nodev,noexec,size=16m,mode=0700",
-    "--volume", `${hostRoot}/runs:/state:rw`,
-    "--volume", `${hostRoot}/source:/source:rw`,
-    image,
-    "internal-publish-resume",
-  ], {
-    input: envelope,
-    timeoutMs: PUBLISH_TIMEOUT_MS + 60_000,
-    maxOutputBytes: 512 * 1024,
-  });
+  const disarmDetachNotice = armDetachNotice(options.deployment);
+  let publisher;
+  try {
+    publisher = await targetExecute(deploymentTarget, [
+      "docker", "run", "--pull=never", "--rm", "-i",
+      "--name", `bimo-${options.deployment}-publisher`,
+      "--user", "0:0",
+      "--read-only",
+      "--cap-drop", "ALL",
+      "--security-opt", "no-new-privileges",
+      "--pids-limit", "128",
+      "--memory", "512m",
+      "--cpus", "0.5",
+      "--tmpfs", "/tmp:rw,nosuid,nodev,noexec,size=32m",
+      "--tmpfs", "/run/bimo-publish:rw,nosuid,nodev,noexec,size=16m,mode=0700",
+      "--volume", `${hostRoot}/runs:/state:rw`,
+      "--volume", `${hostRoot}/source:/source:rw`,
+      image,
+      "internal-publish-resume",
+    ], {
+      input: envelope,
+      timeoutMs: PUBLISH_TIMEOUT_MS + 60_000,
+      maxOutputBytes: 512 * 1024,
+    });
+  } finally {
+    disarmDetachNotice();
+  }
   const response = validateResumedPublication(parseLastJson(publisher.stdout, "pod publisher"));
   if (options.json) process.stdout.write(`${JSON.stringify(response)}\n`);
   else process.stdout.write(`published ${response.runId}\nPR: ${response.publication.url} (draft)\n`);
@@ -2370,7 +2484,7 @@ async function doctor(options) {
           maxOutputBytes: 4 * 1024,
         }).catch(() => fail("reference is not readable"));
         if (!result.stdout.trim()) fail("reference resolved to an empty value");
-        return "reference is readable";
+        return "OpenRouter API key reference is readable";
       });
     } else {
       checks.push(Object.freeze({ name: "secret-ref", status: "skip", reason: "op CLI is unavailable" }));
@@ -2394,8 +2508,8 @@ const COMMAND_HELP = {
   list: "bimo list [--json]\n  List the installed workflow and pod templates.",
   targets: "bimo targets [--json]\n  Probe the local Docker daemon and list the built-in deployment targets.",
   validate: "bimo validate TEMPLATE [--json]\n  Validate one installed template and print its digest.",
-  organize: "bimo organize -p PROMPT [-n 1|2|3] --deployment NAME [target flags] --secret-ref op://VAULT/ITEM/FIELD [--json]\n  Plan a deployment with bounded organizer agents without deploying.",
-  deploy: "bimo deploy TEMPLATE --deployment NAME [target flags] --task-file FILE --secret-ref op://VAULT/ITEM/FIELD [--json]\n  Deploy a template as a bounded Docker fleet.",
+  organize: "bimo organize -p PROMPT [-n 1|2|3] --deployment NAME [target flags] --secret-ref op://VAULT/ITEM/FIELD [--json]\n  Plan a deployment with bounded organizer agents without deploying. --secret-ref must resolve to an OpenRouter API key.",
+  deploy: "bimo deploy TEMPLATE --deployment NAME [target flags] --task-file FILE --secret-ref op://VAULT/ITEM/FIELD --public-url URL [--json]\n  Deploy a template as a bounded Docker fleet. --secret-ref must resolve to an OpenRouter API key.",
   runs: "bimo runs --deployment NAME [target flags] [--json]\n  List recorded runs for a deployment from its durable state root.",
   status: "bimo status --deployment NAME [target flags] [--run ID] [--json]\n  Print the latest run state and last event for a deployment.",
   logs: "bimo logs --deployment NAME [target flags] [--run ID] [--json] [--follow]\n  Print a run log; --follow streams new events until interrupted.",
@@ -2444,7 +2558,7 @@ async function runCommand(argv) {
     process.stdout.write(usage());
     return;
   }
-  if (command === "--version") {
+  if (command === "--version" || command === "version") {
     const manifest = JSON.parse(await readFile(path.join(packageRoot, "package.json"), "utf8"));
     process.stdout.write(`${manifest.version}\n`);
     return;
@@ -2454,18 +2568,16 @@ async function runCommand(argv) {
     return;
   }
   if (command === "list") {
-    const { positional, options } = parseOptions(rest, { booleans: ["json"] });
+    const { positional, options } = parseOptions(rest, { booleans: ["json"], allowed: ["json"] });
     if (positional.length) fail("list accepts no positional arguments");
-    exactOptions(options, ["json"]);
     const templates = await listTemplates();
     if (options.json) process.stdout.write(`${JSON.stringify({ templates })}\n`);
     else templates.forEach(template => process.stdout.write(`${template.name}\t${template.roles.join(" -> ")}\n`));
     return;
   }
   if (command === "targets") {
-    const { positional, options } = parseOptions(rest, { booleans: ["json"] });
+    const { positional, options } = parseOptions(rest, { booleans: ["json"], allowed: ["json"] });
     if (positional.length) fail("targets accepts no positional arguments");
-    exactOptions(options, ["json"]);
     const targets = await listDeploymentTargets();
     if (options.json) process.stdout.write(`${JSON.stringify({ targets })}\n`);
     else targets.forEach(target => process.stdout.write([
@@ -2478,8 +2590,7 @@ async function runCommand(argv) {
     return;
   }
   if (command === "validate") {
-    const { positional, options } = parseOptions(rest, { booleans: ["json"] });
-    exactOptions(options, ["json"]);
+    const { positional, options } = parseOptions(rest, { booleans: ["json"], allowed: ["json"] });
     if (positional.length !== 1) fail("validate requires one template name");
     const loaded = await loadTemplate(positional[0]);
     const result = { valid: true, kind: loaded.kind, template: loaded.name, digest: loaded.digest };
@@ -2487,49 +2598,73 @@ async function runCommand(argv) {
     return;
   }
   if (command === "organize") {
-    const { positional, options } = parseOrganizerOptions(rest);
+    const { positional, options, agentFlag } = parseOrganizerOptions(rest);
     if (positional.length) fail("organize accepts no positional arguments");
-    await organizeRemote(options);
+    await organizeRemote(options, agentFlag);
     return;
   }
   if (command === "deploy") {
-    const { positional, options } = parseOptions(rest, { booleans: ["task-stdin", "json"] });
+    const { positional, options } = parseOptions(rest, {
+      booleans: ["task-stdin", "json"],
+      allowed: DEPLOY_OPTIONS,
+    });
     if (positional.length !== 1) fail("deploy requires one template name");
     await deploy(positional[0], options);
     return;
   }
   if (command === "logs") {
-    const { positional, options } = parseOptions(rest, { booleans: ["json", "follow"] });
+    const { positional, options } = parseOptions(rest, {
+      booleans: ["json", "follow"],
+      allowed: ["deployment", "target", "proxmox", "host", "vmid", "run", "image", "json", "follow"],
+    });
     if (positional.length) fail("logs accepts no positional arguments");
     await remoteLogs(options);
     return;
   }
   if (command === "runs") {
-    const { positional, options } = parseOptions(rest, { booleans: ["json"] });
+    const { positional, options } = parseOptions(rest, {
+      booleans: ["json"],
+      allowed: ["deployment", "target", "proxmox", "host", "vmid", "image", "json"],
+    });
     if (positional.length) fail("runs accepts no positional arguments");
     await remoteRuns(options);
     return;
   }
   if (command === "status") {
-    const { positional, options } = parseOptions(rest, { booleans: ["json"] });
+    const { positional, options } = parseOptions(rest, {
+      booleans: ["json"],
+      allowed: ["deployment", "target", "proxmox", "host", "vmid", "run", "image", "json"],
+    });
     if (positional.length) fail("status accepts no positional arguments");
     await remoteStatus(options);
     return;
   }
   if (command === "doctor") {
-    const { positional, options } = parseOptions(rest, { booleans: ["json"] });
+    const { positional, options } = parseOptions(rest, {
+      booleans: ["json"],
+      allowed: ["deployment", "target", "proxmox", "host", "vmid", "secret-ref", "account", "json"],
+    });
     if (positional.length) fail("doctor accepts no positional arguments");
     await doctor(options);
     return;
   }
   if (command === "cancel") {
-    const { positional, options } = parseOptions(rest, { booleans: ["json"] });
+    const { positional, options } = parseOptions(rest, {
+      booleans: ["json"],
+      allowed: ["deployment", "target", "proxmox", "host", "vmid", "run", "image", "json"],
+    });
     if (positional.length) fail("cancel accepts no positional arguments");
     await remoteCancel(options);
     return;
   }
   if (command === "publish") {
-    const { positional, options } = parseOptions(rest, { booleans: ["json"] });
+    const { positional, options } = parseOptions(rest, {
+      booleans: ["json"],
+      allowed: [
+        "deployment", "target", "proxmox", "host", "vmid", "run",
+        "github-secret-ref", "account", "image", "json",
+      ],
+    });
     if (positional.length) fail("publish accepts no positional arguments");
     await remotePublish(options);
     return;

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { execFile, spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { EventEmitter } from "node:events";
-import { appendFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, mkdtemp, readdir, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import { tmpdir } from "node:os";
 import { promisify } from "node:util";
@@ -174,8 +174,10 @@ const separator = command.indexOf("--");
 const runtimeCommand = separator === -1 ? command : command.slice(separator + 1);
 const log = value => fs.appendFileSync(process.env.BIMO_TEST_LOG, JSON.stringify(value) + "\\n");
 log({ tool: "ssh", args, command });
-if (runtimeCommand[0] === "true" || runtimeCommand[0] === "test") {
+if (runtimeCommand[0] === "true") {
   process.exit(0);
+} else if (runtimeCommand[0] === "test") {
+  process.exit(process.env.BIMO_TEST_STATE_MISSING ? 1 : 0);
 } else if (runtimeCommand[0] === "docker" && runtimeCommand[1] === "kill") {
   const name = runtimeCommand[runtimeCommand.length - 1];
   log({ tool: "docker-kill", name });
@@ -211,6 +213,10 @@ if (runtimeCommand[0] === "true" || runtimeCommand[0] === "test") {
     && runtimeCommand.includes("internal-logs")) {
   process.stdout.write("");
 } else if (runtimeCommand[0] === "docker" && runtimeCommand[1] === "run") {
+  if (process.env.BIMO_TEST_CONTROLLER === "hang") {
+    process.stdin.resume();
+    setTimeout(() => process.exit(0), 30_000);
+  } else {
   let raw = "";
   process.stdin.setEncoding("utf8");
   process.stdin.on("data", chunk => { raw += chunk; });
@@ -340,6 +346,7 @@ if (runtimeCommand[0] === "true" || runtimeCommand[0] === "test") {
       }) + "\\n");
     }
   });
+  }
 }
 `;
   const op = `#!/usr/bin/env node
@@ -795,6 +802,7 @@ test("organize transfers content-verified image without retagging and runs one e
   assert.equal(localCleanup.length, 1);
   assert.ok(remoteCommands.indexOf(remoteCleanup[0]) > remoteCommands.indexOf(remoteRun));
   assert.ok(localCommands.indexOf(localCleanup[0]) > localCommands.findIndex(command => command[0] === "save"));
+  assert.equal(remoteCommands.some(command => command[0] === "rmdir"), false);
 });
 
 test("organize explicit and root prompt aliases preserve short/long option parity", async t => {
@@ -1596,6 +1604,10 @@ test("doctor checks ssh targets and credential readability without printing secr
   const secret = `sk-or-v1-${"k".repeat(32)}`;
   assert.equal(result.stdout.includes(secret), false);
   assert.equal(JSON.stringify(await readCommandLog(tools.logFile)).includes(secret), false);
+  assert.match(
+    report.checks.find(check => check.name === "secret-ref").reason,
+    /OpenRouter API key/,
+  );
 });
 
 test("doctor checks proxmox reachability, guest status, and in-guest docker", async t => {
@@ -1741,7 +1753,7 @@ test("run progress streams bounded event lines and tolerates a missing run", asy
   assert.deepEqual(phases, ["run.started", "gate.finished"]);
 });
 
-test("organize prints the run ID on stderr before long work in human mode", async t => {
+test("organize prints the run ID on stderr once the run starts in human mode", async t => {
   const tools = await fakeDeployTools(t, { controller: "organize-success" });
   const args = organizeArgs("Build a small status page.", 1).filter(value => value !== "--json");
   const result = await invoke(args, { env: tools.env });
@@ -2146,10 +2158,15 @@ test("internal-logs prints a friendly empty state when no runs are recorded", as
 
 test("nested docker error prefixes collapse to one bimo prefix per boundary", async t => {
   const tools = await fakeDeployTools(t);
+  const home = await realpath(await mkdtemp(path.join(tmpdir(), "bimo-home-test-")));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  await mkdir(path.join(home, ".local", "share", "bimo", "deployments", "fleet-demo", "runs"), {
+    recursive: true,
+  });
   const payload = "bimo: docker exited 1: bimo-agent: agent exited 1; errorStatus=401";
   const result = await invoke([
     "logs", "--deployment", "fleet-demo", "--image", "bimo-workflow:test", "--json",
-  ], { env: { ...tools.env, BIMO_TEST_READ_FAIL: payload } });
+  ], { env: { ...tools.env, HOME: home, BIMO_TEST_READ_FAIL: payload } });
   assert.equal(result.code, 1);
   assert.equal(
     result.stderr,
@@ -2189,4 +2206,307 @@ test("internal-publish-resume names the run when no publication-ready record exi
   assert.equal(missing.code, 1);
   assert.match(missing.stderr,
     /no publication-ready record found for run 20240909000000-ffff9999/);
+});
+
+test("organize and deploy print no run ID when the run never starts", async t => {
+  const tools = await fakeDeployTools(t);
+  const env = { ...tools.env, BIMO_TEST_OP_FAIL: "1" };
+  const organize = await invoke(
+    organizeArgs("Build a small status page.").filter(value => value !== "--json"),
+    { env },
+  );
+  assert.equal(organize.code, 1);
+  assert.match(organize.stderr, /failed to resolve --secret-ref via 1Password/);
+  assert.doesNotMatch(organize.stderr, /^run: /m);
+
+  const deploy = await invoke(deployArgs(tools.taskFile).filter(value => value !== "--json"), { env });
+  assert.equal(deploy.code, 1);
+  assert.match(deploy.stderr, /failed to resolve --secret-ref via 1Password/);
+  assert.doesNotMatch(deploy.stderr, /^run: /m);
+
+  const commands = await readCommandLog(tools.logFile);
+  assert.equal(commands.some(entry => (entry.command ?? entry.args ?? [])[0] === "rmdir"), false);
+});
+
+test("runs and status agree on attempts for a run recorded without currentAttempt", async t => {
+  const directory = await mkdtemp(path.join(tmpdir(), "bimo-state-organizer-"));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  const runId = "20240101000000-dddd4444";
+  await mkdir(path.join(directory, runId));
+  await writeFile(path.join(directory, runId, "run.json"), `${JSON.stringify({
+    version: 1,
+    runId,
+    type: "organizer",
+    status: "completed",
+    promptSha256: "a".repeat(64),
+    agents: 1,
+    startedAt: "2024-01-01T00:00:00.000Z",
+    finishedAt: "2024-01-01T00:05:00.000Z",
+  }, null, 2)}\n`);
+  await writeFile(path.join(directory, runId, "events.jsonl"), [
+    JSON.stringify({
+      version: 1, sequence: 1, timestamp: "2024-01-01T00:00:00.000Z", runId, type: "run.started",
+    }),
+    JSON.stringify({
+      version: 1, sequence: 2, timestamp: "2024-01-01T00:05:00.000Z", runId,
+      type: "run.completed", template: "react-app", templateDigest: "b".repeat(64),
+    }),
+  ].join("\n") + "\n");
+  await writeFile(path.join(directory, "latest"), `${runId}\n`);
+
+  const runs = await invoke(["internal-runs", "--state-root", directory, "--deployment", "demo", "--json"]);
+  assert.equal(runs.code, 0, runs.stderr);
+  assert.equal(JSON.parse(runs.stdout).runs[0].attempts, 1);
+
+  const status = await invoke([
+    "internal-status", "--state-root", directory, "--deployment", "demo", "--json",
+  ]);
+  assert.equal(status.code, 0, status.stderr);
+  assert.equal(JSON.parse(status.stdout).attempts, 1);
+});
+
+test("an unknown option without a value reports unknown, not a missing value", async t => {
+  const tools = await fakeDeployTools(t);
+  for (const [args, pattern] of [
+    [["deploy", "react-app", "--bogus"], /unknown option: --bogus/],
+    [["organize", "-p", "Build a small status page.", "--bogus"], /unknown option: --bogus/],
+    [["logs", "--deployment", "fleet-demo", "--bogus"], /unknown option: --bogus/],
+    [["runs", "--deployment", "fleet-demo", "--bogus"], /unknown option: --bogus/],
+    [["status", "--deployment", "fleet-demo", "--bogus"], /unknown option: --bogus/],
+    [["doctor", "--bogus"], /unknown option: --bogus/],
+    [["cancel", "--deployment", "fleet-demo", "--bogus"], /unknown option: --bogus/],
+    [["publish", "--deployment", "fleet-demo", "--bogus"], /unknown option: --bogus/],
+    [["status", "--deployment"], /--deployment requires a value/],
+  ]) {
+    const result = await invoke(args, { env: tools.env });
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, pattern);
+  }
+  assert.deepEqual(await readCommandLog(tools.logFile), []);
+});
+
+test("the -n range error names the flag the user typed", async t => {
+  const tools = await fakeDeployTools(t);
+  const common = [
+    "--deployment", "organizer-demo", "--host", "example.invalid",
+    "--secret-ref", "op://Test/Bimo/openrouter",
+  ];
+  const short = await invoke([
+    "organize", "-p", "Build a small status page.", "-n", "5", ...common,
+  ], { env: tools.env });
+  assert.equal(short.code, 1);
+  assert.match(short.stderr, /-n must be an integer from 1 to 3/);
+
+  const long = await invoke([
+    "organize", "--prompt", "Build a small status page.", "--agents", "5", ...common,
+  ], { env: tools.env });
+  assert.equal(long.code, 1);
+  assert.match(long.stderr, /--agents must be an integer from 1 to 3/);
+  assert.deepEqual(await readCommandLog(tools.logFile), []);
+});
+
+test("bimo version aliases --version and exits 0", async () => {
+  const manifest = JSON.parse(await readFile(path.join(root, "package.json"), "utf8"));
+  const result = await invoke(["version"]);
+  assert.equal(result.code, 0, result.stderr);
+  assert.equal(result.stdout, `${manifest.version}\n`);
+  assert.equal(result.stderr, "");
+});
+
+test("organize and deploy help name the OpenRouter key and deploy shows --public-url", async () => {
+  const deploy = await invoke(["help", "deploy"]);
+  assert.equal(deploy.code, 0, deploy.stderr);
+  assert.match(deploy.stdout, /--public-url URL/);
+  assert.match(deploy.stdout, /--secret-ref must resolve to an OpenRouter API key/);
+
+  const organize = await invoke(["help", "organize"]);
+  assert.equal(organize.code, 0, organize.stderr);
+  assert.match(organize.stdout, /--secret-ref must resolve to an OpenRouter API key/);
+});
+
+test("failed deploy and organize reap the empty deployment state they prepared", async t => {
+  const tools = await fakeDeployTools(t);
+  const result = await invoke(deployArgs(tools.taskFile), { env: tools.env });
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /controller name is already in use/);
+  const remoteCommands = (await readCommandLog(tools.logFile))
+    .filter(entry => entry.tool === "ssh")
+    .map(entry => entry.command);
+  const hostRoot = "/var/lib/bimo/deployments/fleet-demo";
+  const controllerIndex = remoteCommands.findIndex(command => command.includes("internal-run"));
+  const reapIndex = remoteCommands.findIndex(command => command[0] === "rmdir");
+  assert.ok(controllerIndex >= 0, "controller was not launched");
+  assert.ok(reapIndex > controllerIndex, "empty deployment state was not reaped");
+  assert.deepEqual(remoteCommands[reapIndex], [
+    "rmdir", `${hostRoot}/runs`, `${hostRoot}/workspace`, hostRoot,
+  ]);
+});
+
+test("a failed organize reaps the empty deployment state it prepared", async t => {
+  const tools = await fakeDeployTools(t);
+  const result = await invoke(organizeArgs("Build a small status page."), { env: tools.env });
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /controller name is already in use/);
+  const remoteCommands = (await readCommandLog(tools.logFile))
+    .filter(entry => entry.tool === "ssh")
+    .map(entry => entry.command);
+  const hostRoot = "/var/lib/bimo/deployments/organizer-demo";
+  const controllerIndex = remoteCommands.findIndex(command => command.includes("internal-organize"));
+  const reapIndex = remoteCommands.findIndex(command => command[0] === "rmdir");
+  assert.ok(controllerIndex >= 0, "controller was not launched");
+  assert.ok(reapIndex > controllerIndex, "empty deployment state was not reaped");
+  assert.deepEqual(remoteCommands[reapIndex], [
+    "rmdir", `${hostRoot}/runs`, `${hostRoot}/worktrees`, hostRoot,
+  ]);
+});
+
+test("read commands report an absent deployment without creating state on the target", async t => {
+  const tools = await fakeDeployTools(t);
+  const env = { ...tools.env, BIMO_TEST_STATE_MISSING: "1" };
+  const runId = "20240101000000-abcd1234";
+
+  const runs = await invoke([
+    "runs", "--deployment", "fleet-demo", "--host", "example.invalid",
+    "--image", "bimo-workflow:test", "--json",
+  ], { env });
+  assert.equal(runs.code, 0, runs.stderr);
+  assert.deepEqual(JSON.parse(runs.stdout), { deployment: "fleet-demo", runs: [] });
+
+  const status = await invoke([
+    "status", "--deployment", "fleet-demo", "--host", "example.invalid",
+    "--image", "bimo-workflow:test", "--json",
+  ], { env });
+  assert.equal(status.code, 0, status.stderr);
+  assert.deepEqual(JSON.parse(status.stdout), {
+    deployment: "fleet-demo", runId: null, state: "none", phase: null,
+    startedAt: null, finishedAt: null, attempts: 0, lastEvent: null,
+  });
+
+  const statusRun = await invoke([
+    "status", "--deployment", "fleet-demo", "--host", "example.invalid",
+    "--run", runId, "--image", "bimo-workflow:test",
+  ], { env });
+  assert.equal(statusRun.code, 1);
+  assert.match(statusRun.stderr, new RegExp(`unknown run: ${runId}`));
+
+  const logs = await invoke([
+    "logs", "--deployment", "fleet-demo", "--host", "example.invalid",
+    "--image", "bimo-workflow:test",
+  ], { env });
+  assert.equal(logs.code, 0, logs.stderr);
+  assert.equal(logs.stdout, "no runs recorded for deployment fleet-demo\n");
+
+  const logsRun = await invoke([
+    "logs", "--deployment", "fleet-demo", "--host", "example.invalid",
+    "--run", runId, "--image", "bimo-workflow:test",
+  ], { env });
+  assert.equal(logsRun.code, 1);
+  assert.match(logsRun.stderr, new RegExp(`unknown run: ${runId}`));
+
+  const follow = await invoke([
+    "logs", "--deployment", "fleet-demo", "--host", "example.invalid",
+    "--image", "bimo-workflow:test", "--follow",
+  ], { env });
+  assert.equal(follow.code, 0, follow.stderr);
+  assert.equal(follow.stdout, "no runs recorded for deployment fleet-demo\n");
+
+  const cancel = await invoke([
+    "cancel", "--deployment", "fleet-demo", "--host", "example.invalid",
+    "--run", runId, "--image", "bimo-workflow:test",
+  ], { env });
+  assert.equal(cancel.code, 1);
+  assert.match(cancel.stderr, new RegExp(`unknown run: ${runId}`));
+
+  const publish = await invoke([
+    "publish", "--deployment", "pod-demo", "--host", "example.invalid",
+    "--run", runId, "--github-secret-ref", "op://Test/Bimo publisher/github",
+    "--image", "bimo-workflow:test",
+  ], { env });
+  assert.equal(publish.code, 1);
+  assert.match(publish.stderr, new RegExp(`no publication-ready record found for run ${runId}`));
+
+  const publishLatest = await invoke([
+    "publish", "--deployment", "pod-demo", "--host", "example.invalid",
+    "--github-secret-ref", "op://Test/Bimo publisher/github", "--image", "bimo-workflow:test",
+  ], { env });
+  assert.equal(publishLatest.code, 1);
+  assert.match(publishLatest.stderr, /no latest run is recorded/);
+
+  const internals = (await readCommandLog(tools.logFile))
+    .filter(entry => entry.tool === "ssh")
+    .map(entry => entry.command)
+    .filter(command => command.some(value => value.startsWith("internal-")));
+  assert.deepEqual(internals, []);
+});
+
+test("local read commands report an absent deployment without creating state directories", async t => {
+  const tools = await fakeDeployTools(t);
+  const home = await realpath(await mkdtemp(path.join(tmpdir(), "bimo-home-test-")));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  const env = { ...tools.env, HOME: home };
+
+  const logs = await invoke([
+    "logs", "--deployment", "fleet-demo", "--image", "bimo-workflow:test",
+  ], { env });
+  assert.equal(logs.code, 0, logs.stderr);
+  assert.equal(logs.stdout, "no runs recorded for deployment fleet-demo\n");
+
+  const runs = await invoke([
+    "runs", "--deployment", "fleet-demo", "--image", "bimo-workflow:test", "--json",
+  ], { env });
+  assert.equal(runs.code, 0, runs.stderr);
+  assert.deepEqual(JSON.parse(runs.stdout), { deployment: "fleet-demo", runs: [] });
+
+  const status = await invoke([
+    "status", "--deployment", "fleet-demo", "--image", "bimo-workflow:test",
+  ], { env });
+  assert.equal(status.code, 0, status.stderr);
+  assert.match(status.stdout, /state: none/);
+
+  assert.equal((await readdir(home)).includes(".local"), false);
+});
+
+test("cancel pins the terminal vocabulary of a cancelled run", async t => {
+  const tools = await fakeDeployTools(t);
+  const result = await invoke([
+    "cancel", "--deployment", "fleet-demo", "--host", "example.invalid",
+    "--image", "bimo-workflow:test",
+  ], { env: { ...tools.env, BIMO_TEST_KILL: "bimo-fleet-demo-controller" } });
+  assert.equal(result.code, 0, result.stderr);
+  assert.equal(
+    result.stdout,
+    "sent SIGTERM to bimo-fleet-demo-controller;"
+      + " the run will finish as failed with reason 'deployment cancelled'\n",
+  );
+});
+
+test("SIGINT to an attached deploy detaches with a cancel hint and exit 130", async t => {
+  const tools = await fakeDeployTools(t, { controller: "hang" });
+  const child = spawn(process.execPath, [cli, ...deployArgs(tools.taskFile)], {
+    cwd: root,
+    env: tools.env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  t.after(() => child.kill("SIGKILL"));
+  const stdout = [];
+  const stderr = [];
+  child.stdout.on("data", chunk => stdout.push(chunk));
+  child.stderr.on("data", chunk => stderr.push(chunk));
+  const deadline = Date.now() + 10_000;
+  let launched = false;
+  while (Date.now() < deadline && !launched) {
+    const log = await readFile(tools.logFile, "utf8").catch(() => "");
+    launched = log.includes("internal-run");
+    if (!launched) await new Promise(resolve => setTimeout(resolve, 50));
+  }
+  assert.ok(launched, "controller was not launched");
+  child.kill("SIGINT");
+  const code = await new Promise(resolve => child.on("close", resolve));
+  assert.equal(code, 130);
+  assert.equal(Buffer.concat(stdout).toString("utf8"), "");
+  assert.equal(
+    Buffer.concat(stderr).toString("utf8"),
+    "detaching; the run continues on the target"
+      + " — use bimo cancel --deployment fleet-demo to stop it\n",
+  );
 });


### PR DESCRIPTION
Closes #32
Closes #33
Closes #34
Closes #35

Fixes from the second dogfood-alpha wave:

- **#32 Phantom run IDs / attempts disagreement**: the `run: <id>` stderr line is deferred until the run actually starts (after secret resolution, image prep, and state prep), so pre-launch failures no longer print an ID for a run that was never recorded. `summarizeRun` now derives attempts from `events.jsonl` when `run.json` has a state but no `currentAttempt` (organizer runs), so `runs` and `status` report the same value.
- **#33 Discoverability**: organize/deploy help and doctor's secret-ref check state the secret must be an OpenRouter API key; `help deploy` shows `--public-url URL`; unknown flags with no following token now report `unknown option: --bogus` (unknown-option detection moved before missing-value detection in both parsers); the `-n` range error names the flag the user typed; `bimo version` aliases `--version`.
- **#34 Ghost deployment dirs**: read paths (`logs`/`runs`/`status`/`cancel --run`/`publish`) probe state-root existence before any container runs, so Docker never auto-creates the bind-mounted `runs/` dir — absent deployments get the empty/none/unknown-run answers directly. Failed deploy/organize runs reap the state they prepared via `rmdir` (removes only empty directories, so recorded state is never touched).
- **#35 Cancel vocabulary / SIGINT**: SIGINT on an attached deploy/organize/publish prints `detaching; the run continues on the target — use bimo cancel --deployment <name> to stop it` to stderr before exiting 130 (signal behavior unchanged). Cancel output now matches reality: `the run will finish as failed with reason 'deployment cancelled'`. README pins both semantics.

Tests: 259 → 271 (`npm test` fully green, `node --check` clean).