### PR TITLE
Release v0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,21 +236,21 @@ Controller-owned verification is the separate fixed step described above.
 
 ## Install from GitHub
 
-Bimo is not published to the npm registry. Download the v0.5.0 release
+Bimo is not published to the npm registry. Download the v0.6.0 release
 tarball and checksum, verify the exact file, then install it locally:
 
 ```bash
 curl --fail --location --remote-name \
-  https://github.com/zaycruz/bimo/releases/download/v0.5.0/bimo-workflow-0.5.0.tgz
+  https://github.com/zaycruz/bimo/releases/download/v0.6.0/bimo-workflow-0.6.0.tgz
 curl --fail --location --remote-name \
-  https://github.com/zaycruz/bimo/releases/download/v0.5.0/bimo-workflow-0.5.0.tgz.sha256
+  https://github.com/zaycruz/bimo/releases/download/v0.6.0/bimo-workflow-0.6.0.tgz.sha256
 
 # macOS
-shasum --algorithm 256 --check bimo-workflow-0.5.0.tgz.sha256
+shasum --algorithm 256 --check bimo-workflow-0.6.0.tgz.sha256
 # Linux
-sha256sum --check bimo-workflow-0.5.0.tgz.sha256
+sha256sum --check bimo-workflow-0.6.0.tgz.sha256
 
-npm install --global ./bimo-workflow-0.5.0.tgz
+npm install --global ./bimo-workflow-0.6.0.tgz
 bimo list --json
 bimo validate parallel-engineering-pod
 BIMO_PACKAGE_ROOT="$(npm root --global)/bimo-workflow"
@@ -534,7 +534,7 @@ sequential deploys also accept `--port`. `logs` accepts `--run`, `--image`, and
 `--json`.
 
 Defaults are port `8080`, model `openrouter/deepseek/deepseek-v4-flash`, and
-image tag `bimo-workflow:0.5.0`. `--account` selects a 1Password account;
+image tag `bimo-workflow:0.6.0`. `--account` selects a 1Password account;
 `--json` requests machine-readable output.
 
 Quote each `op://` reference as one shell argument. Vault, item, and field names

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bimo-workflow",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bimo-workflow",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "bin": {
         "bimo": "bin/bimo"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bimo-workflow",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Deploy bounded, auditable agent workflows as ephemeral Docker fleets.",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/bimo.mjs
+++ b/src/bimo.mjs
@@ -39,7 +39,7 @@ import { loadWorkflow, runWorkflow } from "./workflow.mjs";
 const packageRoot = path.resolve(import.meta.dirname, "..");
 const templateRoot = path.join(packageRoot, "templates");
 const organizerInstructionsPath = path.join(packageRoot, "etc", "organizer", "organizer.md");
-const DEFAULT_IMAGE = "bimo-workflow:0.5.0";
+const DEFAULT_IMAGE = "bimo-workflow:0.6.0";
 const DEFAULT_MODEL = "openrouter/deepseek/deepseek-v4-flash";
 const POD_REPOSITORY = "https://github.com/zaycruz/bimo.git";
 const POD_TARGET_BRANCH = "main";

--- a/test/brand.test.mjs
+++ b/test/brand.test.mjs
@@ -30,7 +30,7 @@ test("publishes the clean-break Bimo product contract", async () => {
   const packageJson = JSON.parse(await readFile(path.join(root, "package.json"), "utf8"));
 
   assert.equal(packageJson.name, "bimo-workflow");
-  assert.equal(packageJson.version, "0.5.0");
+  assert.equal(packageJson.version, "0.6.0");
   assert.deepEqual(packageJson.bin, { bimo: "bin/bimo" });
   assert.equal(packageJson.repository.url, "git+https://github.com/zaycruz/bimo.git");
   assert.equal(packageJson.homepage, "https://github.com/zaycruz/bimo#readme");


### PR DESCRIPTION
Bumps the version to 0.6.0 ahead of the v0.6.0 release.

- `package.json` / `package-lock.json`: 0.5.0 → 0.6.0
- Default image tag `bimo-workflow:0.6.0`
- README install section downloads the v0.6.0 tarball and checksum
- Brand contract test tracks the new version

This is the first licensed release (Apache-2.0) and ships the full operator-recovery wave.