### PR TITLE
docs: add AGENTS.md and fix stale README claims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,62 @@
+# Working on Bimo
+
+Bimo is a zero-dependency Node.js ESM CLI that deploys bounded, auditable
+agent workflows as ephemeral Docker fleets. This file is the whole
+orientation: verification loop, hard rules, PR flow, and the design docs.
+
+## Verification loop
+
+Node.js 22+. No install step; there is nothing to install.
+
+```sh
+npm test            # full suite: node --test test/*.test.mjs (271 tests)
+for f in bin/bimo src/*.mjs test/*.mjs; do node --check "$f"; done
+npm pack --dry-run  # verify the package manifest and shipped file set
+```
+
+All three must pass before opening a PR, including for docs-only changes.
+
+## Hard rules
+
+- **Zero npm dependencies.** The package imports only the Node.js standard
+  library. Do not add a `dependencies` field, a lockfile entry, or a
+  vendored library. If a capability seems missing, the answer is a small
+  local module, not a package.
+- **`fail()` for every error.** Each module defines a local
+  `fail(message)` that throws an `Error`. No custom error classes, no
+  error-code enums.
+- **Strict argv, no shell interpolation.** Every external command is a
+  validated argv array executed without a shell (`execute`,
+  `commandForTarget`). Names, paths, images, and identifiers are
+  regex-validated before they reach argv. Never build a command string.
+- **Bound everything.** Every read, exec, and stream carries a byte cap, a
+  timeout, and a count or size limit. No unbounded buffers, no open-ended
+  waits.
+- **Frozen option objects.** Parsed options and cross-module inputs are
+  `Object.freeze`d at the boundary and treated as immutable.
+- **Exact-shape receipts.** Every JSON receipt — agent, verifier,
+  artifact, plan, error — is validated against an exact field set
+  (`assertExactFields`). Unknown or missing fields fail closed.
+
+## PR flow
+
+- One worktree per change:
+  `git worktree add .worktrees/<name> -b <branch>`.
+- PRs squash-merge to `main`.
+- Required checks: `verify`, `verify-macos` (ci), `analyze` (codeql),
+  `dependency-review`, `scan` (gitleaks).
+
+## Design docs
+
+- [docs/targets.md](docs/targets.md) — the closed deployment-target
+  registry (`local`, `ssh`, `proxmox-lxc`) and why it is not a plugin
+  system.
+- [docs/runtime-contract.md](docs/runtime-contract.md) — the bounded
+  runtime contract a second adapter must satisfy, and the security
+  invariants it may not weaken.
+- [docs/templates.md](docs/templates.md) — the data-only template
+  boundary: manifest schema, digest binding, customization path, and
+  non-promises.
+
+README.md is the user-facing contract. A change that alters CLI behavior
+updates the README and the affected examples in the same PR.

--- a/README.md
+++ b/README.md
@@ -570,8 +570,8 @@ requires `--deployment` and `--secret-ref`. Sequential workflows also require
 repository URL, an immutable `--base-sha`, and `--target-branch main`.
 
 Optional shared flags are `--account`, `--model`, `--image`, and `--json`;
-sequential deploys also accept `--port`. `logs` accepts `--run`, `--image`, and
-`--json`.
+sequential deploys also accept `--port`. `logs` accepts `--run`, `--image`,
+`--follow`, and `--json`.
 
 Defaults are port `8080`, model `openrouter/deepseek/deepseek-v4-flash`, and
 image tag `bimo-workflow:0.6.0`. `--account` selects a 1Password account;
@@ -633,8 +633,9 @@ owned workspaces. An abrupt host or container loss can leave a `running` record
 and private temporary roots. The pod does not resume a partial Planner, writer,
 or checker attempt. Confirm no controller or publisher is active, preserve the
 run records for diagnosis, then recover only that dedicated deployment root
-before starting a new run. The internal publisher can reconcile an interrupted
-durable publication, but v0.6.0 has no general user-facing resume command.
+before starting a new run. An interrupted durable publication can be resumed
+with `bimo publish`; v0.6.0 has no general user-facing resume command for
+runs.
 
 ## Security boundary
 


### PR DESCRIPTION
Refs #7

## AGENTS.md (new)

Repo-root orientation for external contributors, matching the docs/ tone:

- Verification loop: `npm test` (271 tests), `node --check` sweep over `bin/bimo src/*.mjs test/*.mjs`, `npm pack --dry-run`.
- Hard rules: zero npm dependencies, `fail()` for errors, strict argv with no shell interpolation, bounded reads/timeouts/output, frozen option objects, exact-shape receipts.
- PR flow: one worktree per change, squash merge, required checks `verify`, `verify-macos`, `analyze`, `dependency-review`, `scan`.
- Pointers to docs/targets.md, docs/runtime-contract.md, docs/templates.md.

## README stale-claim fixes (minimal diffs)

- `logs` flag summary now includes `--follow` (previously only mentioned in prose above; cross-checked against the `logs` allowed-options list in `src/bimo.mjs`).
- State-and-logs recovery paragraph: an interrupted durable publication is resumed with the user-facing `bimo publish` command; the previous wording ("the internal publisher can reconcile...") predated the operator-recovery wave that made `publish` a public command.

## examples/ refresh

No changes required, and no deletions. `examples/*.md` and `examples/prompts/*.md` are task prompts fed to `--task-file`; they contain no CLI invocations, so there is nothing to validate against `usage()`/`COMMAND_HELP`. The commands that reference these files live in README.md and were verified against current `usage()` output (`deploy`, `organize`/`-p` shorthand, `logs --run --json`, `--target` forms).

## Sweep results

- Verified against `src/bimo.mjs` directly: deploy stdout receipt shape (`deployed X as Y\nrun: ...\nurl: ...`), run ID printed to stderr once the run record exists, 30s heartbeat phases (`preparing image`, `running controller`), progress on stderr, `--json` receipts on stdout, `no runs recorded for deployment NAME` (exit 0), SIGINT detach notice with exit 130, cancel vocabulary (`failed` with reason `deployment cancelled`, no distinct `cancelled` state), `--pull=never` on every `docker run`/`create`, image-presence preflight on read paths, doctor check names and output format, `bimo list --json` shape, and defaults (port 8080, model `openrouter/deepseek/deepseek-v4-flash`, image `bimo-workflow:0.6.0`).
- docs/organize.md, docs/targets.md, docs/templates.md, docs/runtime-contract.md: no stale claims found; voting rules, digest binding, target registry, and the `--pull=never`/preflight contract all match the code. Left untouched.
- No doc-vs-code contradictions where the code is wrong were found.

## Verification

- `npm test`: 271/271 pass.
- `node --check` over `bin/bimo src/*.mjs test/*.mjs`: clean.
- `npm pack --dry-run`: 58 files, no issues.