### PR TITLE
Agent-runtime registry seam (opencode adapter)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,9 @@ All three must pass before opening a PR, including for docs-only changes.
 - [docs/runtime-contract.md](docs/runtime-contract.md) — the bounded
   runtime contract a second adapter must satisfy, and the security
   invariants it may not weaken.
+- [docs/agent-runtimes.md](docs/agent-runtimes.md) — the closed
+  agent-runtime registry (`opencode`), the adapter contract a second
+  agent runtime must satisfy, and the invariants it may not weaken.
 - [docs/templates.md](docs/templates.md) — the data-only template
   boundary: manifest schema, digest binding, customization path, and
   non-promises.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,44 @@
+ARG AGENT_RUNTIME=opencode
+
 FROM docker:29.7.2-cli@sha256:000bb62ff495f986c9f5578eb67cc2cb98b91138eda81d7762d5371eb8a497fe AS docker-cli
 
-FROM node:22-slim@sha256:83f487e0a63425e5b4d146fb5e5be574bcbe1b7b843d3ebafdd95eaf7767a7e5
+FROM node:22-slim@sha256:83f487e0a63425e5b4d146fb5e5be574bcbe1b7b843d3ebafdd95eaf7767a7e5 AS base
 
-ARG OPENCODE_VERSION=1.18.23
 ARG NPM_VERSION=12.0.2
-ARG TARGETARCH
 
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends ca-certificates git \
     && rm -rf /var/lib/apt/lists/* \
     && npm install --global "npm@${NPM_VERSION}" \
-    && case "${TARGETARCH}" in \
+    && npm cache clean --force
+
+COPY --from=docker-cli /usr/local/bin/docker /usr/local/bin/docker
+
+ENV NODE_ENV=production
+
+WORKDIR /app
+
+COPY --chown=root:root package.json ./
+COPY --chown=root:root bin ./bin
+COPY --chown=root:root src ./src
+COPY --chown=root:root starters ./starters
+COPY --chown=root:root templates ./templates
+COPY --chown=root:root etc/organizer ./etc/organizer
+
+COPY --chown=root:root starters/react/package.json starters/react/package-lock.json /opt/bimo-react/
+RUN cd /opt/bimo-react \
+    && npm ci --include=dev --ignore-scripts --no-audit --no-fund \
+    && npm cache clean --force
+
+RUN chmod 0555 /app/bin/bimo /app/bin/bimo-git-askpass \
+    && chown -R root:root /app
+
+FROM base AS runtime-opencode
+
+ARG OPENCODE_VERSION=1.18.23
+ARG TARGETARCH
+
+RUN case "${TARGETARCH}" in \
       amd64) OPENCODE_ARCH=x64 ;; \
       arm64) OPENCODE_ARCH=arm64 ;; \
       *) echo "unsupported target architecture: ${TARGETARCH}" >&2; exit 1 ;; \
@@ -23,28 +51,15 @@ RUN apt-get update \
     && test "$(opencode --version)" = "${OPENCODE_VERSION}" \
     && npm cache clean --force
 
-COPY --from=docker-cli /usr/local/bin/docker /usr/local/bin/docker
-
-ENV NODE_ENV=production \
-    OPENCODE_CONFIG=/etc/opencode/opencode.json
-
-WORKDIR /app
-
-COPY --chown=root:root package.json ./
-COPY --chown=root:root bin ./bin
-COPY --chown=root:root src ./src
-COPY --chown=root:root starters ./starters
-COPY --chown=root:root templates ./templates
-COPY --chown=root:root etc/organizer ./etc/organizer
 COPY --chown=root:root --chmod=0444 etc/opencode/opencode.json /etc/opencode/opencode.json
 
-COPY --chown=root:root starters/react/package.json starters/react/package-lock.json /opt/bimo-react/
-RUN cd /opt/bimo-react \
-    && npm ci --include=dev --ignore-scripts --no-audit --no-fund \
-    && npm cache clean --force
+ENV OPENCODE_CONFIG=/etc/opencode/opencode.json \
+    BIMO_AGENT_RUNTIME=opencode
 
-RUN chmod 0555 /app/bin/bimo /app/bin/bimo-git-askpass /etc/opencode \
-    && chown -R root:root /app /etc/opencode
+RUN chmod 0555 /etc/opencode \
+    && chown -R root:root /etc/opencode
+
+FROM runtime-${AGENT_RUNTIME} AS final
 
 USER node
 ENTRYPOINT ["/app/bin/bimo"]

--- a/README.md
+++ b/README.md
@@ -158,6 +158,28 @@ the closed registry only after its end-to-end deploy, log, cancel, and
 cleanup evidence exists. [The target boundary](docs/targets.md) explains why
 this is deliberately not a plugin system yet.
 
+## Agent runtimes
+
+The agent CLI a role container spawns is selected from a closed registry —
+one entry today:
+
+| Runtime | Agent CLI | Default image tag | Selection |
+| --- | --- | --- | --- |
+| `opencode` | `opencode run` (pinned in the image) | `bimo-workflow:0.6.0` | Default, or `--agent-runtime opencode` |
+
+`bimo deploy` and `bimo organize` accept `--agent-runtime NAME`. The name is
+validated against the registry, baked into the image with
+`--build-arg AGENT_RUNTIME`, carried to the controller in the run envelope,
+and passed to every agent container as `BIMO_AGENT_RUNTIME`. Bounded output,
+the role timeout, the kill-tree, the gateway-only network, and the
+`/handoff/result.json` contract are enforced by the dispatcher and are
+identical for every runtime. Without `--image`, the default tag is
+`bimo-workflow:0.6.0` for `opencode` and `bimo-workflow:0.6.0-<name>` for any
+future entry.
+[The agent runtime contract](docs/agent-runtimes.md) defines the adapter
+shape, the invariants a second runtime may not weaken, and why the registry
+is deliberately not a plugin system.
+
 ## Templates
 
 Each template is one directory holding one JSON manifest and one Markdown
@@ -569,12 +591,14 @@ requires `--deployment` and `--secret-ref`. Sequential workflows also require
 `--public-url`. The fixed pod instead requires `--github-secret-ref`, the fixed
 repository URL, an immutable `--base-sha`, and `--target-branch main`.
 
-Optional shared flags are `--account`, `--model`, `--image`, and `--json`;
-sequential deploys also accept `--port`. `logs` accepts `--run`, `--image`,
-`--follow`, and `--json`.
+Optional shared flags are `--account`, `--model`, `--image`, `--agent-runtime`,
+and `--json`; sequential deploys also accept `--port`. `logs` accepts `--run`,
+`--image`, `--follow`, and `--json`.
 
-Defaults are port `8080`, model `openrouter/deepseek/deepseek-v4-flash`, and
-image tag `bimo-workflow:0.6.0`. `--account` selects a 1Password account;
+Defaults are port `8080`, model `openrouter/deepseek/deepseek-v4-flash`, agent
+runtime `opencode`, and image tag `bimo-workflow:0.6.0` (a non-default
+`--agent-runtime` derives `bimo-workflow:0.6.0-<name>` instead).
+`--account` selects a 1Password account;
 `--json` requests machine-readable output.
 
 Quote each `op://` reference as one shell argument. Vault, item, and field names

--- a/docs/agent-runtimes.md
+++ b/docs/agent-runtimes.md
@@ -1,0 +1,116 @@
+# Agent runtimes
+
+Bimo separates workflow semantics from the agent CLI that executes a role. A
+template says which roles run and how their receipts transition. An **agent
+runtime** is the agent program one role container actually spawns: the CLI,
+its arguments, its environment, and the dialect of its output stream.
+
+The registry in `src/agent-runtime.mjs` is deliberately closed:
+
+| Runtime | Agent CLI | Default image tag | Selection |
+| --- | --- | --- | --- |
+| `opencode` | `opencode run` (pinned `opencode-ai` in the image) | `bimo-workflow:0.6.0` | Default, or `--agent-runtime opencode` |
+
+`opencode` is the only entry today. This document defines the adapter
+contract a second runtime must satisfy. It exists so the runtime set grows by
+evidence, not by adding a plugin system — the same rule
+[docs/targets.md](targets.md) sets for placement and
+[docs/runtime-contract.md](runtime-contract.md) sets for the execution
+runtime.
+
+## The adapter contract
+
+An adapter is one frozen object in the registry with a validated lowercase
+name and three operations. `agentRuntimeFor(name)` resolves a name to its
+adapter and fails closed on anything else; there is no registration, no
+discovery, and no way to name a runtime that is not built in.
+
+1. **`spawnArgv({ model, role })`** returns the complete argv array for the
+   agent process, command included. The dispatcher
+   (`src/agent.mjs`) validates the result — 1 to 64 non-empty bounded
+   strings, no control characters — and executes it without a shell. An
+   adapter never interpolates values into a command string.
+2. **`spawnEnv({ gateway })`** returns the complete child environment: at
+   most 32 `UPPER_SNAKE` entries of bounded strings, with the validated
+   `BIMO_GATEWAY_URL` as the only network authority. The child never inherits
+   the controller environment; every entry is explicit.
+3. **`createDiagnostics()``** returns a fresh `{ stdout, stderr, failure }`
+   sink. The dispatcher feeds every output chunk to it; on a non-zero exit,
+   `failure(code)` returns a one-line, bounded summary. Diagnostics must
+   never replay agent output content — event counts, byte totals, and an
+   extracted HTTP status, never model text or secrets.
+
+That is the whole contract. The opencode adapter is the reference
+implementation: its argv pins `opencode run --pure --auto` against the
+mounted instructions file, its environment carries `OPENCODE_CONFIG`, and its
+diagnostics parse the opencode JSON event stream
+(`createOpenCodeDiagnostics`).
+
+## Invariants an adapter may not weaken
+
+The cross-runtime guarantees live in the dispatcher, not the adapter. An
+adapter supplies argv, env, and diagnostics — nothing more. If a runtime
+cannot satisfy one of these, it is not registered.
+
+- **Bounded output.** Combined stdout and stderr are capped at 1 MiB; the
+  process tree is terminated past the cap and every byte is hashed into the
+  run's `outputSha256` receipt regardless of runtime.
+- **Bounded lifetime.** The `--timeout-seconds` budget applies to every
+  runtime. Expiry terminates the whole process group (detached kill-tree,
+  SIGTERM then SIGKILL), not just the direct child.
+- **The handoff contract.** The agent reads its prompt from
+  `/instructions/instructions.md` (1 to 262144 bytes) and writes exactly one
+  regular, non-symlink `/handoff/result.json` (2 to 65536 bytes). The
+  dispatcher validates both; a runtime that cannot produce the handoff file
+  fails the role.
+- **Gateway-only network authority.** The only network endpoint the agent
+  receives is the validated `http://gateway:PORT/api/v1` URL, checked against
+  a strict regex before spawn. The container topology (no direct egress) is
+  enforced by the execution runtime and is identical for every agent runtime.
+- **Operator-only authority.** Runtime selection happens only in the operator
+  CLI (`--agent-runtime`) and is carried through the controller envelopes as
+  exact-shape validated data. Templates, roles, and organizer votes can never
+  choose an agent runtime, image, or command.
+- **Fail closed everywhere.** An unknown `BIMO_AGENT_RUNTIME` in the agent
+  container, an unknown name in an envelope, or an adapter result that
+  violates the shape checks stops the run before any agent process starts.
+
+## Selection, envelopes, and the image
+
+`bimo deploy` and `bimo organize` accept `--agent-runtime NAME`. The chosen
+name travels in the run envelope to the in-container controller, which
+validates it against the same registry and passes it to every agent container
+as `BIMO_AGENT_RUNTIME`. The agent entrypoint resolves it through
+`agentRuntimeFor` before touching the workspace, and the `run.started` event
+records it next to the model and image digest.
+
+Each runtime is a different image: the agent CLI is baked in, never installed
+at run time. The Dockerfile is staged — a shared `base` stage (system
+packages, the Bimo sources, the React starter layer, the bundled Docker CLI)
+plus one `runtime-<name>` stage per registry entry. The `runtime-opencode`
+stage installs the pinned `opencode-ai` version, copies
+`etc/opencode/opencode.json`, and stamps `ENV BIMO_AGENT_RUNTIME=opencode`;
+the final stage is `runtime-${AGENT_RUNTIME}`. `prepareImage` passes
+`--build-arg AGENT_RUNTIME=<name>` and, after building, fails closed unless
+the image's `Config.Env` carries the matching `BIMO_AGENT_RUNTIME` — with one
+exception: a defaulted (not explicit) `--agent-runtime` accepts an old image
+that predates the stamp. A plain `docker build` with no build arguments
+selects `opencode` and produces the same behavior as the pre-staged image.
+
+When `--image` is not passed, the default tag derives from the runtime:
+`bimo-workflow:0.6.0` for `opencode` (unchanged), and
+`bimo-workflow:0.6.0-<name>` for any future entry. Read commands (`logs`,
+`runs`, `status`, `cancel`, `publish`) do not launch agents; with a
+non-default runtime image, pass `--image` explicitly to them.
+
+## Why this is not a plugin system
+
+One runtime exists. Loading arbitrary executable agent plugins now would
+require a versioned ABI, discovery rules, trust and signing policy, secret
+routing, and failure cleanup without adding a new capability — and it would
+hand templates and organizers a way to smuggle in executables, which the
+operator-only authority rule forbids. When a second agent runtime is
+implemented, it lands as a built-in entry behind this registry, satisfying
+the same contract and invariants. If two or more external runtimes then need
+independent release cycles, the registry can become a versioned plugin
+boundary with evidence instead of speculation.

--- a/src/agent-runtime.mjs
+++ b/src/agent-runtime.mjs
@@ -1,0 +1,141 @@
+import process from "node:process";
+
+const AGENT_RUNTIME_NAME = /^[a-z][a-z0-9-]{0,31}$/;
+const MAX_DIAGNOSTIC_LINE_BYTES = 65_536;
+const DIAGNOSTIC_EVENT_TYPES = new Set([
+  "error",
+  "reasoning",
+  "step_finish",
+  "step_start",
+  "text",
+  "tool_use",
+]);
+
+export const AGENT_INSTRUCTIONS_PATH = "/instructions/instructions.md";
+export const DEFAULT_AGENT_RUNTIME = "opencode";
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function findHttpStatus(value, depth = 0, budget = { visited: 0 }) {
+  if (!value || typeof value !== "object" || Array.isArray(value)
+      || depth > 4 || budget.visited >= 32) return null;
+  budget.visited += 1;
+  for (const key of ["status", "statusCode"]) {
+    const raw = value[key];
+    const status = typeof raw === "string" && /^\d{3}$/u.test(raw) ? Number(raw) : raw;
+    if (Number.isInteger(status) && status >= 100 && status <= 599) return status;
+  }
+  for (const nested of Object.values(value)) {
+    const status = findHttpStatus(nested, depth + 1, budget);
+    if (status !== null) return status;
+  }
+  return null;
+}
+
+export function createOpenCodeDiagnostics() {
+  let stdoutBytes = 0;
+  let stderrBytes = 0;
+  let stdoutLine = "";
+  let discardingLine = false;
+  let finished = false;
+  const decoder = new TextDecoder("utf-8");
+  const eventCounts = new Map();
+  let errorStatus = null;
+  const recordEvent = line => {
+    if (!line || Buffer.byteLength(line) > MAX_DIAGNOSTIC_LINE_BYTES) return;
+    let event;
+    try {
+      event = JSON.parse(line);
+    } catch {
+      return;
+    }
+    if (!event || typeof event !== "object" || Array.isArray(event)
+        || !DIAGNOSTIC_EVENT_TYPES.has(event.type)) return;
+    eventCounts.set(event.type, (eventCounts.get(event.type) ?? 0) + 1);
+    if (event.type === "error") errorStatus = findHttpStatus(event.error);
+  };
+  return {
+    stdout(chunk) {
+      stdoutBytes += chunk.length;
+      let text = decoder.decode(chunk, { stream: true });
+      if (discardingLine) {
+        const newline = text.indexOf("\n");
+        if (newline === -1) return;
+        discardingLine = false;
+        text = text.slice(newline + 1);
+      }
+      const lines = `${stdoutLine}${text}`.split("\n");
+      stdoutLine = lines.pop() ?? "";
+      for (const line of lines) recordEvent(line);
+      if (Buffer.byteLength(stdoutLine) > MAX_DIAGNOSTIC_LINE_BYTES) {
+        stdoutLine = "";
+        discardingLine = true;
+      }
+    },
+    stderr(chunk) {
+      stderrBytes += chunk.length;
+    },
+    failure(code) {
+      if (finished) throw new Error("OpenCode diagnostics already finalized");
+      finished = true;
+      const finalLine = discardingLine ? "" : `${stdoutLine}${decoder.decode()}`;
+      if (finalLine) recordEvent(finalLine);
+      const exit = Number.isInteger(code) ? `agent exited ${code}` : "agent exited on signal";
+      const events = [...eventCounts.entries()]
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([type, count]) => `${type}:${count}`)
+        .join(",");
+      return [
+        exit,
+        ...(events ? [`events=${events}`] : []),
+        ...(errorStatus === null ? [] : [`errorStatus=${errorStatus}`]),
+        `stdoutBytes=${stdoutBytes}`,
+        `stderrBytes=${stderrBytes}`,
+      ].join("; ");
+    },
+  };
+}
+
+const AGENT_RUNTIMES = Object.freeze({
+  opencode: Object.freeze({
+    name: "opencode",
+    spawnArgv({ model, role }) {
+      return [
+        "opencode",
+        "run",
+        "--pure",
+        "--auto",
+        "--agent", "build",
+        "--format", "json",
+        "--dir", "/workspace",
+        "--model", model,
+        "--file", AGENT_INSTRUCTIONS_PATH,
+        "--title", `bimo-${role}`,
+        "Follow the attached Bimo instructions exactly.",
+      ];
+    },
+    spawnEnv({ gateway }) {
+      return {
+        PATH: process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin",
+        HOME: "/home/node",
+        TMPDIR: "/tmp",
+        LANG: "C.UTF-8",
+        CI: "1",
+        BIMO_GATEWAY_URL: gateway,
+        OPENCODE_CONFIG: "/etc/opencode/opencode.json",
+      };
+    },
+    createDiagnostics: createOpenCodeDiagnostics,
+  }),
+});
+
+export const AGENT_RUNTIME_NAMES = Object.freeze(Object.keys(AGENT_RUNTIMES));
+
+export function agentRuntimeFor(name) {
+  if (!AGENT_RUNTIME_NAME.test(name ?? "") || !Object.hasOwn(AGENT_RUNTIMES, name)) {
+    fail(`unknown agent runtime: ${name ?? ""}`);
+  }
+  return AGENT_RUNTIMES[name];
+}

--- a/src/agent.mjs
+++ b/src/agent.mjs
@@ -7,18 +7,15 @@ import path from "node:path";
 import process from "node:process";
 import { pathToFileURL } from "node:url";
 
+import {
+  AGENT_INSTRUCTIONS_PATH,
+  DEFAULT_AGENT_RUNTIME,
+  agentRuntimeFor,
+} from "./agent-runtime.mjs";
+
 const MODEL = /^openrouter\/[a-z0-9][a-z0-9._/-]{2,127}$/;
 const MAX_OUTPUT_BYTES = 1_048_576;
-const MAX_DIAGNOSTIC_LINE_BYTES = 65_536;
-const INSTRUCTIONS_PATH = "/instructions/instructions.md";
-const DIAGNOSTIC_EVENT_TYPES = new Set([
-  "error",
-  "reasoning",
-  "step_finish",
-  "step_start",
-  "text",
-  "tool_use",
-]);
+const UNSAFE_CONTROL = /[\u0000-\u001f\u007f]/u;
 
 function fail(message) {
   throw new Error(message);
@@ -41,120 +38,60 @@ function parseArgs(argv) {
   return { model: options.model, timeoutSeconds, role: options.role };
 }
 
-function findHttpStatus(value, depth = 0, budget = { visited: 0 }) {
-  if (!value || typeof value !== "object" || Array.isArray(value)
-      || depth > 4 || budget.visited >= 32) return null;
-  budget.visited += 1;
-  for (const key of ["status", "statusCode"]) {
-    const raw = value[key];
-    const status = typeof raw === "string" && /^\d{3}$/u.test(raw) ? Number(raw) : raw;
-    if (Number.isInteger(status) && status >= 100 && status <= 599) return status;
+function assertSpawnArgv(argv) {
+  if (!Array.isArray(argv) || argv.length < 1 || argv.length > 64
+      || argv.some(value => typeof value !== "string" || !value || value.length > 1_024
+        || UNSAFE_CONTROL.test(value))) {
+    fail("agent runtime returned an invalid spawn argv");
   }
-  for (const nested of Object.values(value)) {
-    const status = findHttpStatus(nested, depth + 1, budget);
-    if (status !== null) return status;
-  }
-  return null;
+  return argv;
 }
 
-export function createOpenCodeDiagnostics() {
-  let stdoutBytes = 0;
-  let stderrBytes = 0;
-  let stdoutLine = "";
-  let discardingLine = false;
-  let finished = false;
-  const decoder = new TextDecoder("utf-8");
-  const eventCounts = new Map();
-  let errorStatus = null;
-  const recordEvent = line => {
-    if (!line || Buffer.byteLength(line) > MAX_DIAGNOSTIC_LINE_BYTES) return;
-    let event;
-    try {
-      event = JSON.parse(line);
-    } catch {
-      return;
-    }
-    if (!event || typeof event !== "object" || Array.isArray(event)
-        || !DIAGNOSTIC_EVENT_TYPES.has(event.type)) return;
-    eventCounts.set(event.type, (eventCounts.get(event.type) ?? 0) + 1);
-    if (event.type === "error") errorStatus = findHttpStatus(event.error);
-  };
-  return {
-    stdout(chunk) {
-      stdoutBytes += chunk.length;
-      let text = decoder.decode(chunk, { stream: true });
-      if (discardingLine) {
-        const newline = text.indexOf("\n");
-        if (newline === -1) return;
-        discardingLine = false;
-        text = text.slice(newline + 1);
-      }
-      const lines = `${stdoutLine}${text}`.split("\n");
-      stdoutLine = lines.pop() ?? "";
-      for (const line of lines) recordEvent(line);
-      if (Buffer.byteLength(stdoutLine) > MAX_DIAGNOSTIC_LINE_BYTES) {
-        stdoutLine = "";
-        discardingLine = true;
-      }
-    },
-    stderr(chunk) {
-      stderrBytes += chunk.length;
-    },
-    failure(code) {
-      if (finished) throw new Error("OpenCode diagnostics already finalized");
-      finished = true;
-      const finalLine = discardingLine ? "" : `${stdoutLine}${decoder.decode()}`;
-      if (finalLine) recordEvent(finalLine);
-      const exit = Number.isInteger(code) ? `agent exited ${code}` : "agent exited on signal";
-      const events = [...eventCounts.entries()]
-        .sort(([left], [right]) => left.localeCompare(right))
-        .map(([type, count]) => `${type}:${count}`)
-        .join(",");
-      return [
-        exit,
-        ...(events ? [`events=${events}`] : []),
-        ...(errorStatus === null ? [] : [`errorStatus=${errorStatus}`]),
-        `stdoutBytes=${stdoutBytes}`,
-        `stderrBytes=${stderrBytes}`,
-      ].join("; ");
-    },
-  };
+function assertSpawnEnv(env) {
+  if (!env || typeof env !== "object" || Array.isArray(env)
+      || Object.keys(env).length < 1 || Object.keys(env).length > 32
+      || Object.entries(env).some(([key, value]) => !/^[A-Z][A-Z0-9_]{0,63}$/.test(key)
+        || typeof value !== "string" || !value || value.length > 1_024
+        || UNSAFE_CONTROL.test(value))) {
+    fail("agent runtime returned an invalid spawn environment");
+  }
+  return env;
 }
 
-function runOpenCode({ model, timeoutSeconds, role }) {
+function assertDiagnostics(diagnostics) {
+  if (!diagnostics || typeof diagnostics !== "object"
+      || typeof diagnostics.stdout !== "function" || typeof diagnostics.stderr !== "function"
+      || typeof diagnostics.failure !== "function") {
+    fail("agent runtime returned invalid diagnostics");
+  }
+  return diagnostics;
+}
+
+function runAgent(runtime, { model, timeoutSeconds, role }) {
   return new Promise((resolve, reject) => {
     const gateway = process.env.BIMO_GATEWAY_URL;
     if (!gateway || !/^http:\/\/[a-z0-9.-]+:\d{2,5}\/api\/v1$/.test(gateway)) {
       reject(new Error("BIMO_GATEWAY_URL is invalid"));
       return;
     }
-    const child = spawn("opencode", [
-      "run",
-      "--pure",
-      "--auto",
-      "--agent", "build",
-      "--format", "json",
-      "--dir", "/workspace",
-      "--model", model,
-      "--file", INSTRUCTIONS_PATH,
-      "--title", `bimo-${role}`,
-      "Follow the attached Bimo instructions exactly.",
-    ], {
+    let argv;
+    let env;
+    let diagnostics;
+    try {
+      argv = assertSpawnArgv(runtime.spawnArgv({ model, role }));
+      env = assertSpawnEnv(runtime.spawnEnv({ gateway }));
+      diagnostics = assertDiagnostics(runtime.createDiagnostics());
+    } catch (error) {
+      reject(error);
+      return;
+    }
+    const child = spawn(argv[0], argv.slice(1), {
       detached: true,
-      env: {
-        PATH: process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin",
-        HOME: "/home/node",
-        TMPDIR: "/tmp",
-        LANG: "C.UTF-8",
-        CI: "1",
-        BIMO_GATEWAY_URL: gateway,
-        OPENCODE_CONFIG: "/etc/opencode/opencode.json",
-      },
+      env,
       stdio: ["ignore", "pipe", "pipe"],
     });
     const hash = createHash("sha256");
     let outputBytes = 0;
-    const diagnostics = createOpenCodeDiagnostics();
     let settled = false;
     let timedOut = false;
 
@@ -199,12 +136,13 @@ function runOpenCode({ model, timeoutSeconds, role }) {
 
 async function main() {
   const options = parseArgs(process.argv.slice(2));
-  const prompt = await readFile(INSTRUCTIONS_PATH);
+  const runtime = agentRuntimeFor(process.env.BIMO_AGENT_RUNTIME ?? DEFAULT_AGENT_RUNTIME);
+  const prompt = await readFile(AGENT_INSTRUCTIONS_PATH);
   if (!prompt.length || prompt.length > 256 * 1024) fail("prompt must contain 1 to 262144 bytes");
   const existing = await lstat("/handoff/result.json").catch(() => null);
   if (existing) await unlink("/handoff/result.json");
 
-  const result = await runOpenCode(options);
+  const result = await runAgent(runtime, options);
   const handoff = await lstat("/handoff/result.json").catch(() => null);
   if (!handoff?.isFile() || handoff.isSymbolicLink() || handoff.size < 2 || handoff.size > 65_536) {
     fail("agent did not create a regular bounded /handoff/result.json");

--- a/src/bimo.mjs
+++ b/src/bimo.mjs
@@ -13,6 +13,7 @@ import {
 import path from "node:path";
 import process from "node:process";
 
+import { AGENT_RUNTIME_NAMES, DEFAULT_AGENT_RUNTIME } from "./agent-runtime.mjs";
 import { DockerRuntime } from "./docker-runtime.mjs";
 import {
   builtInTargetCatalog,
@@ -68,16 +69,16 @@ const POD_DEPLOY_OPTIONS = [
 ];
 const ORGANIZE_OPTIONS = [
   "prompt", "agents", "deployment", "target", "proxmox", "host", "vmid",
-  "secret-ref", "account", "model", "image", "json",
+  "secret-ref", "account", "model", "image", "agent-runtime", "json",
 ];
 const DEPLOY_WORKFLOW_OPTIONS = [
   "deployment", "target", "proxmox", "host", "vmid", "task-file", "task-stdin",
-  "secret-ref", "account", "public-url", "port", "model", "image", "json",
+  "secret-ref", "account", "public-url", "port", "model", "image", "agent-runtime", "json",
 ];
 const DEPLOY_POD_OPTIONS = [
   "deployment", "target", "proxmox", "host", "vmid", "task-file", "task-stdin",
   "secret-ref", "github-secret-ref", "account", "repository", "base-sha",
-  "target-branch", "model", "image", "json",
+  "target-branch", "model", "image", "agent-runtime", "json",
 ];
 const DEPLOY_OPTIONS = [...new Set([...DEPLOY_WORKFLOW_OPTIONS, ...DEPLOY_POD_OPTIONS])];
 const DEPLOYMENT_LAYOUTS = {
@@ -532,16 +533,39 @@ function imageTransferTag(imageId) {
   return `bimo-transfer:${imageId.slice(7, 19)}-${randomUUID().replaceAll("-", "")}`;
 }
 
-async function prepareImage(target, image, { retag = true } = {}) {
+function defaultImageFor(agentRuntime) {
+  if (!AGENT_RUNTIME_NAMES.includes(agentRuntime)) fail("agent runtime is invalid");
+  return agentRuntime === DEFAULT_AGENT_RUNTIME ? DEFAULT_IMAGE : `${DEFAULT_IMAGE}-${agentRuntime}`;
+}
+
+function imageAgentRuntime(image) {
+  const entry = image.env.find(value => value.startsWith("BIMO_AGENT_RUNTIME="));
+  return entry === undefined ? null : entry.slice("BIMO_AGENT_RUNTIME=".length);
+}
+
+async function prepareImage(target, image, {
+  retag = true,
+  agentRuntime = DEFAULT_AGENT_RUNTIME,
+  agentRuntimeExplicit = false,
+} = {}) {
+  if (!AGENT_RUNTIME_NAMES.includes(agentRuntime)) fail("agent runtime is invalid");
   const platform = await targetPlatform(target);
-  const buildArgs = target.kind === "local"
-    ? ["build", "--tag", image, packageRoot]
-    : ["build", "--platform", platform, "--tag", image, packageRoot];
+  const buildArgs = [
+    "build",
+    ...(target.kind === "local" ? [] : ["--platform", platform]),
+    "--build-arg", `AGENT_RUNTIME=${agentRuntime}`,
+    "--tag", image,
+    packageRoot,
+  ];
   await execute("docker", buildArgs);
   const imageResult = await execute("docker", ["image", "inspect", image]);
   const localImage = parseImageInspect(imageResult.stdout, "local");
   if (localImage.platform !== platform) {
     fail(`built image platform ${localImage.platform} does not match target ${platform}`);
+  }
+  const builtRuntime = imageAgentRuntime(localImage);
+  if (builtRuntime !== agentRuntime && (agentRuntimeExplicit || builtRuntime !== null)) {
+    fail(`built image agent runtime ${builtRuntime ?? "unset"} does not match --agent-runtime ${agentRuntime}`);
   }
   if (target.kind === "local") {
     return { remoteImage: localImage, transferTag: null };
@@ -752,6 +776,9 @@ function parseImageInspect(raw, label) {
   return {
     imageId: value.Id,
     platform: `${value.Os}/${value.Architecture}`,
+    env: Array.isArray(normalizedConfig.Env)
+      ? normalizedConfig.Env.filter(entry => typeof entry === "string")
+      : [],
     contentFingerprint: createHash("sha256").update(canonicalJson(content)).digest("hex"),
   };
 }
@@ -884,7 +911,9 @@ async function deploy(template, options) {
   if (!options.deployment) fail("--deployment is required");
   if (!NAME.test(options.deployment)) fail("--deployment must use lowercase letters, numbers, and dashes");
   const deploymentTarget = resolveDeploymentTarget(options);
-  const image = options.image ?? DEFAULT_IMAGE;
+  const agentRuntime = options["agent-runtime"] ?? DEFAULT_AGENT_RUNTIME;
+  if (!AGENT_RUNTIME_NAMES.includes(agentRuntime)) fail("--agent-runtime must name a built-in agent runtime");
+  const image = options.image ?? defaultImageFor(agentRuntime);
   if (!IMAGE.test(image)) fail("--image is invalid");
   const model = options.model ?? DEFAULT_MODEL;
   if (!/^openrouter\/[a-z0-9][a-z0-9._/-]{2,127}$/.test(model)) fail("--model is invalid");
@@ -923,7 +952,10 @@ async function deploy(template, options) {
       ? await resolveGitHubSecret(options["github-secret-ref"], options.account)
       : null;
     heartbeat?.setPhase("preparing image");
-    const prepared = await prepareImage(deploymentTarget, image);
+    const prepared = await prepareImage(deploymentTarget, image, {
+      agentRuntime,
+      agentRuntimeExplicit: options["agent-runtime"] !== undefined,
+    });
     const remoteImage = prepared.remoteImage;
     transferTag = prepared.transferTag;
     if (progress) {
@@ -955,6 +987,7 @@ async function deploy(template, options) {
         task,
         key: openRouterKey,
         model,
+        agentRuntime,
         image: remoteImage.imageId,
         repository: POD_REPOSITORY,
         baseSha: options["base-sha"],
@@ -1045,6 +1078,7 @@ async function deploy(template, options) {
         task,
         key: openRouterKey,
         model,
+        agentRuntime,
         image: remoteImage.imageId,
         port,
         publicUrl: publicUrl.toString().replace(/\/$/, ""),
@@ -1102,7 +1136,9 @@ async function organizeRemote(options, agentFlag = "--agents") {
   if (!/^[1-3]$/u.test(agentsText)) fail(`${agentFlag} must be an integer from 1 to 3`);
   const agents = Number(agentsText);
   if (!options["secret-ref"]) fail("--secret-ref is required");
-  const image = options.image ?? DEFAULT_IMAGE;
+  const agentRuntime = options["agent-runtime"] ?? DEFAULT_AGENT_RUNTIME;
+  if (!AGENT_RUNTIME_NAMES.includes(agentRuntime)) fail("--agent-runtime must name a built-in agent runtime");
+  const image = options.image ?? defaultImageFor(agentRuntime);
   if (!IMAGE.test(image)) fail("--image is invalid");
   const model = options.model ?? DEFAULT_MODEL;
   if (!/^openrouter\/[a-z0-9][a-z0-9._/-]{2,127}$/.test(model)) fail("--model is invalid");
@@ -1120,7 +1156,11 @@ async function organizeRemote(options, agentFlag = "--agents") {
   try {
     let openRouterKey = await resolveSecret(options["secret-ref"], options.account);
     heartbeat?.setPhase("preparing image");
-    const prepared = await prepareImage(deploymentTarget, image, { retag: false });
+    const prepared = await prepareImage(deploymentTarget, image, {
+      retag: false,
+      agentRuntime,
+      agentRuntimeExplicit: options["agent-runtime"] !== undefined,
+    });
     const remoteImage = prepared.remoteImage;
     transferTag = prepared.transferTag;
     if (progress) {
@@ -1151,6 +1191,7 @@ async function organizeRemote(options, agentFlag = "--agents") {
       agents,
       key: openRouterKey,
       model,
+      agentRuntime,
       image: remoteImage.imageId,
     });
     openRouterKey = "";
@@ -1237,6 +1278,7 @@ export async function runController({
       workspace,
       runId,
       model: envelope.model,
+      agentRuntime: envelope.agentRuntime,
       imageDigest,
       deadlineAt,
       clock,
@@ -1341,7 +1383,7 @@ async function internalRun(options) {
   const raw = await readStdin(128 * 1024);
   let envelope;
   try { envelope = JSON.parse(raw); } catch { fail("invalid controller envelope"); }
-  const expected = ["version", "template", "templateDigest", "deployment", "task", "key", "model", "image", "port", "publicUrl", "runId"].sort();
+  const expected = ["version", "template", "templateDigest", "deployment", "task", "key", "model", "agentRuntime", "image", "port", "publicUrl", "runId"].sort();
   if (!envelope || typeof envelope !== "object" || Array.isArray(envelope)
       || Object.keys(envelope).sort().some((key, index) => key !== expected[index])
       || Object.keys(envelope).length !== expected.length) {
@@ -1350,6 +1392,7 @@ async function internalRun(options) {
   if (envelope.version !== 1 || !NAME.test(envelope.deployment ?? "") || !NAME.test(envelope.template ?? "")
       || !controllerHostRootIsValid(options["host-root"], envelope.deployment, options["local-home"])
       || !TEMPLATE_DIGEST.test(envelope.templateDigest ?? "") || !SHA256.test(envelope.image ?? "")
+      || !AGENT_RUNTIME_NAMES.includes(envelope.agentRuntime)
       || !RUN_ID.test(envelope.runId ?? "")) {
     fail("controller envelope is invalid");
   }
@@ -1362,6 +1405,7 @@ async function internalRun(options) {
     localHome: options["local-home"],
     key: envelope.key,
     model: envelope.model,
+    agentRuntime: envelope.agentRuntime,
     port: envelope.port,
     publicUrl: envelope.publicUrl,
   });
@@ -1418,7 +1462,7 @@ async function internalPrepare(options) {
 async function internalOrganize(options) {
   exactOptions(options, ["host-root", "local-home"]);
   const envelope = await readJsonEnvelope(128 * 1024, [
-    "version", "deployment", "runId", "prompt", "agents", "key", "model", "image",
+    "version", "deployment", "runId", "prompt", "agents", "key", "model", "agentRuntime", "image",
   ], "organizer controller");
   if (envelope.version !== 1 || !NAME.test(envelope.deployment ?? "")
       || !controllerHostRootIsValid(options["host-root"], envelope.deployment, options["local-home"])
@@ -1426,6 +1470,7 @@ async function internalOrganize(options) {
       || !Number.isInteger(envelope.agents) || envelope.agents < 1 || envelope.agents > 3
       || !/^sk-or-v1-[A-Za-z0-9_-]{32,}$/.test(envelope.key ?? "")
       || !/^openrouter\/[a-z0-9][a-z0-9._/-]{2,127}$/.test(envelope.model ?? "")
+      || !AGENT_RUNTIME_NAMES.includes(envelope.agentRuntime)
       || !SHA256.test(envelope.image ?? "")) {
     fail("organizer controller envelope is invalid");
   }
@@ -1444,6 +1489,7 @@ async function internalOrganize(options) {
     localHome: options["local-home"],
     key: envelope.key,
     model: envelope.model,
+    agentRuntime: envelope.agentRuntime,
     modelConcurrency: envelope.agents,
     modelRequestLimit: 100,
   });
@@ -1454,6 +1500,7 @@ async function internalOrganize(options) {
     catalog,
     baseInstructions,
     model: envelope.model,
+    agentRuntime: envelope.agentRuntime,
     runtime,
     runId: envelope.runId,
   });
@@ -1463,7 +1510,7 @@ async function internalOrganize(options) {
 async function internalPodRun(options) {
   exactOptions(options, ["host-root", "local-home"]);
   const envelope = await readJsonEnvelope(128 * 1024, [
-    "version", "template", "templateDigest", "deployment", "task", "key", "model", "image",
+    "version", "template", "templateDigest", "deployment", "task", "key", "model", "agentRuntime", "image",
     "repository", "baseSha", "targetBranch", "runId",
   ], "pod controller");
   if (envelope.version !== 1 || !NAME.test(envelope.deployment ?? "")
@@ -1474,6 +1521,7 @@ async function internalPodRun(options) {
       || Buffer.byteLength(envelope.task) > 64 * 1024
       || !/^sk-or-v1-[A-Za-z0-9_-]{32,}$/.test(envelope.key ?? "")
       || !/^openrouter\/[a-z0-9][a-z0-9._/-]{2,127}$/.test(envelope.model ?? "")
+      || !AGENT_RUNTIME_NAMES.includes(envelope.agentRuntime)
       || !SHA256.test(envelope.image ?? "") || envelope.repository !== POD_REPOSITORY
       || !GIT_SHA.test(envelope.baseSha ?? "") || envelope.targetBranch !== POD_TARGET_BRANCH
       || !RUN_ID.test(envelope.runId ?? "")) {
@@ -1512,6 +1560,7 @@ async function internalPodRun(options) {
     localHome: options["local-home"],
     key: envelope.key,
     model: envelope.model,
+    agentRuntime: envelope.agentRuntime,
     modelConcurrency: Object.keys(loaded.template.writers).length,
     modelRequestLimit: 300,
   });

--- a/src/docker-runtime.mjs
+++ b/src/docker-runtime.mjs
@@ -14,6 +14,7 @@ import {
 } from "node:fs/promises";
 import path from "node:path";
 
+import { DEFAULT_AGENT_RUNTIME, agentRuntimeFor } from "./agent-runtime.mjs";
 import { isDeploymentHostRoot } from "./deployment-target.mjs";
 
 const NAME = /^[a-z][a-z0-9-]{0,31}$/;
@@ -259,11 +260,13 @@ export function agentCreateArgs({
   promptHost,
   access,
   model,
+  agentRuntime = DEFAULT_AGENT_RUNTIME,
   timeoutSeconds,
   nameSuffix = `${role}-${step}`,
   writeMounts,
 }) {
   if (!EXECUTION_ID.test(nameSuffix)) fail("invalid agent execution name");
+  agentRuntimeFor(agentRuntime);
   const workspaceMounts = writableWorkspaceMounts(workspaceHost, access, writeMounts);
   const name = containerName(deployment, nameSuffix);
   return [
@@ -278,6 +281,7 @@ export function agentCreateArgs({
     "--tmpfs", "/home/node:rw,nosuid,nodev,size=512m,uid=1000,gid=1000",
     "--tmpfs", "/instructions:rw,nosuid,nodev,noexec,size=64k,uid=1000,gid=1000",
     "--env", "BIMO_GATEWAY_URL=http://gateway:8787/api/v1",
+    "--env", `BIMO_AGENT_RUNTIME=${agentRuntime}`,
     "--mount", bind(workspaceHost, "/workspace", workspaceMounts.rootReadOnly),
     ...(workspaceMounts.maskGit ? ["--mount", bind("/dev/null", "/workspace/.git", true)] : []),
     ...workspaceMounts.mounts.flatMap(({ source, target }) => ["--mount", bind(source, target, false)]),
@@ -799,6 +803,7 @@ export class DockerRuntime {
     stateRoot = "/state",
     key,
     model,
+    agentRuntime = DEFAULT_AGENT_RUNTIME,
     modelConcurrency = 1,
     modelRequestLimit = 100,
     port,
@@ -812,6 +817,7 @@ export class DockerRuntime {
     if (path.resolve(stateRoot) !== stateRoot) fail("Bimo state root must be canonical");
     if (!SAFE_IMAGE.test(image)) fail("invalid image reference");
     if (!MODEL.test(model)) fail("invalid model reference");
+    agentRuntimeFor(agentRuntime);
     if (!Number.isInteger(modelConcurrency)
         || modelConcurrency < 1
         || modelConcurrency > MAX_MODEL_CONCURRENCY) {
@@ -841,6 +847,7 @@ export class DockerRuntime {
     this.stateRoot = path.resolve(stateRoot);
     this.key = key;
     this.model = model;
+    this.agentRuntime = agentRuntime;
     this.modelConcurrency = modelConcurrency;
     this.modelRequestLimit = modelRequestLimit;
     this.port = port ?? null;
@@ -1168,6 +1175,7 @@ export class DockerRuntime {
       promptHost: hostPrompt,
       access,
       model: this.model,
+      agentRuntime: this.agentRuntime,
       timeoutSeconds,
       nameSuffix: containerSuffix,
       writeMounts,

--- a/src/organizer-controller.mjs
+++ b/src/organizer-controller.mjs
@@ -138,6 +138,7 @@ export async function runOrganizerController({
   catalog,
   baseInstructions,
   model,
+  agentRuntime = "unspecified",
   runtime,
   stateRoot = "/state",
   worktreesRoot = "/worktrees",
@@ -187,6 +188,7 @@ export async function runOrganizerController({
       promptSha256,
       agents: validated.agents,
       model,
+      agentRuntime,
       imageDigest,
     });
     await runtime.start({ deadlineAt, bootstrap: false });

--- a/src/workflow.mjs
+++ b/src/workflow.mjs
@@ -443,6 +443,7 @@ export async function runWorkflow({
   publish,
   runId = randomUUID(),
   model = "unspecified",
+  agentRuntime = "unspecified",
   imageDigest = "unspecified",
   now = () => new Date(),
   clock = () => Date.now(),
@@ -501,6 +502,7 @@ export async function runWorkflow({
     taskSha256: digest(task),
     previousRunId: previous.previousRunId,
     model,
+    agentRuntime,
     imageDigest,
   });
 

--- a/test/agent-runtime.test.mjs
+++ b/test/agent-runtime.test.mjs
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  AGENT_INSTRUCTIONS_PATH,
+  AGENT_RUNTIME_NAMES,
+  DEFAULT_AGENT_RUNTIME,
+  agentRuntimeFor,
+  createOpenCodeDiagnostics,
+} from "../src/agent-runtime.mjs";
+
+test("the agent runtime registry is closed, frozen, and defaults to opencode", () => {
+  assert.deepEqual([...AGENT_RUNTIME_NAMES], ["opencode"]);
+  assert.ok(Object.isFrozen(AGENT_RUNTIME_NAMES));
+  assert.equal(DEFAULT_AGENT_RUNTIME, "opencode");
+  const runtime = agentRuntimeFor("opencode");
+  assert.equal(runtime.name, "opencode");
+  assert.ok(Object.isFrozen(runtime));
+  assert.equal(agentRuntimeFor("opencode"), runtime);
+});
+
+test("unknown or malformed runtime names fail closed", () => {
+  for (const name of [
+    "bogus", "OpenCode", "opencode;id", "opencode$(id)", "opencode ai",
+    "../opencode", "", "-opencode", "opencode_ai",
+  ]) {
+    assert.throws(() => agentRuntimeFor(name), new RegExp(`unknown agent runtime: ${name.replace(/[$()*+.?[\\\]^{|}]/g, "\\$&")}`));
+  }
+  assert.throws(() => agentRuntimeFor(undefined), /unknown agent runtime/);
+  assert.throws(() => agentRuntimeFor(null), /unknown agent runtime/);
+});
+
+test("the opencode adapter builds the exact bounded spawn argv", () => {
+  const argv = agentRuntimeFor("opencode").spawnArgv({
+    model: "openrouter/deepseek/deepseek-v4-flash",
+    role: "qa",
+  });
+  assert.deepEqual(argv, [
+    "opencode",
+    "run",
+    "--pure",
+    "--auto",
+    "--agent", "build",
+    "--format", "json",
+    "--dir", "/workspace",
+    "--model", "openrouter/deepseek/deepseek-v4-flash",
+    "--file", AGENT_INSTRUCTIONS_PATH,
+    "--title", "bimo-qa",
+    "Follow the attached Bimo instructions exactly.",
+  ]);
+  assert.equal(AGENT_INSTRUCTIONS_PATH, "/instructions/instructions.md");
+});
+
+test("the opencode adapter exposes only the bounded spawn environment", () => {
+  const runtime = agentRuntimeFor("opencode");
+  const env = runtime.spawnEnv({ gateway: "http://gateway:8787/api/v1" });
+  assert.deepEqual(Object.keys(env).sort(), [
+    "BIMO_GATEWAY_URL", "CI", "HOME", "LANG", "OPENCODE_CONFIG", "PATH", "TMPDIR",
+  ]);
+  assert.equal(env.BIMO_GATEWAY_URL, "http://gateway:8787/api/v1");
+  assert.equal(env.OPENCODE_CONFIG, "/etc/opencode/opencode.json");
+  assert.equal(env.HOME, "/home/node");
+  assert.ok(env.PATH.length > 0);
+
+  env.BIMO_GATEWAY_URL = "http://attacker:1/api/v1";
+  const fresh = runtime.spawnEnv({ gateway: "http://gateway:8787/api/v1" });
+  assert.equal(fresh.BIMO_GATEWAY_URL, "http://gateway:8787/api/v1");
+});
+
+test("opencode diagnostics count bounded JSON events without leaking content", () => {
+  const diagnostics = createOpenCodeDiagnostics();
+  diagnostics.stdout(Buffer.from('{"type":"step_start"}\n{"type":"error","error":{"status":500}}\n{"type":"text","part":{"text":"hidden model text"}}\n'));
+  diagnostics.stderr(Buffer.from("raw sk-hidden"));
+
+  const summary = diagnostics.failure(1);
+  assert.match(summary, /^agent exited 1; /u);
+  assert.match(summary, /events=error:1,step_start:1,text:1/u);
+  assert.match(summary, /errorStatus=500/u);
+  assert.match(summary, /stderrBytes=13$/u);
+  assert.doesNotMatch(summary, /hidden/u);
+
+  assert.throws(() => diagnostics.failure(1), /already finalized/);
+});

--- a/test/agent.test.mjs
+++ b/test/agent.test.mjs
@@ -4,7 +4,7 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
-import { createOpenCodeDiagnostics } from "../src/agent.mjs";
+import { createOpenCodeDiagnostics } from "../src/agent-runtime.mjs";
 
 const bimoScript = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -43,4 +43,31 @@ test("bin bimo dispatches the agent entrypoint", async () => {
   assert.deepEqual([code, signal], [1, null]);
   assert.equal(Buffer.concat(stdout).toString("utf8"), "");
   assert.equal(Buffer.concat(stderr).toString("utf8"), "bimo-agent: invalid option: --bad\n");
+});
+
+test("the agent entrypoint rejects an unknown BIMO_AGENT_RUNTIME before any workspace work", async () => {
+  const child = spawn(process.execPath, [
+    bimoScript,
+    "agent",
+    "--model", "openrouter/deepseek/deepseek-v4-flash",
+    "--timeout-seconds", "10",
+    "--role", "qa",
+  ], {
+    env: { BIMO_AGENT_RUNTIME: "bogus" },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const stdout = [];
+  const stderr = [];
+  child.stdout.on("data", chunk => stdout.push(chunk));
+  child.stderr.on("data", chunk => stderr.push(chunk));
+  const [code, signal] = await new Promise(resolve => {
+    child.once("exit", (...result) => resolve(result));
+  });
+
+  assert.deepEqual([code, signal], [1, null]);
+  assert.equal(Buffer.concat(stdout).toString("utf8"), "");
+  assert.equal(
+    Buffer.concat(stderr).toString("utf8"),
+    "bimo-agent: unknown agent runtime: bogus\n",
+  );
 });

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -103,6 +103,7 @@ async function fakeDeployTools(t, {
   remoteLayers = BASE_LAYERS,
   remotePlatform = "linux/amd64",
   localArchitecture = "amd64",
+  localConfig = BASE_CONFIG,
   controller = "conflict",
   missingOp = false,
 } = {}) {
@@ -379,7 +380,10 @@ else {
       DOCKER_HOST: "",
       BIMO_TEST_LOG: logFile,
       BIMO_TEST_DOCKER_ENDPOINT: "unix:///tmp/bimo-test-docker.sock",
-      BIMO_TEST_LOCAL_INSPECT: imageInspect(LOCAL_IMAGE_ID, { architecture: localArchitecture }),
+      BIMO_TEST_LOCAL_INSPECT: imageInspect(LOCAL_IMAGE_ID, {
+        architecture: localArchitecture,
+        config: localConfig,
+      }),
       BIMO_TEST_REMOTE_INSPECT: imageInspect(remoteImageId, {
         architecture: remotePlatform.split("/")[1],
         config: remoteConfig,
@@ -621,6 +625,80 @@ test("deploy defaults to local Docker without SSH or image transfer", async t =>
   assert.equal(envelope.runId, response.runId);
 });
 
+test("deploy builds with the AGENT_RUNTIME build-arg and defaults the opencode image tag", async t => {
+  const tools = await fakeDeployTools(t, {
+    controller: "workflow-success",
+    localArchitecture: "arm64",
+  });
+  const args = deployArgs(tools.taskFile).filter((value, index, all) => (
+    value !== "--host" && all[index - 1] !== "--host"
+      && value !== "--image" && all[index - 1] !== "--image"
+  ));
+  const result = await invoke(args, { env: tools.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  const entries = await readCommandLog(tools.logFile);
+  const docker = entries.filter(entry => entry.tool === "docker").map(entry => entry.args);
+  const build = docker.find(command => command[0] === "build");
+  assert.ok(build);
+  assert.equal(build[build.indexOf("--tag") + 1], "bimo-workflow:0.6.0");
+  assert.equal(build[build.indexOf("--build-arg") + 1], "AGENT_RUNTIME=opencode");
+  const envelope = entries.find(entry => entry.tool === "local-controller-envelope");
+  assert.ok(envelope.fields.includes("agentRuntime"));
+});
+
+test("deploy and organize reject an unknown --agent-runtime before any Docker work", async t => {
+  const tools = await fakeDeployTools(t);
+  for (const args of [
+    [...deployArgs(tools.taskFile), "--agent-runtime", "bogus"],
+    [...organizeArgs("Build a small status page.", 1), "--agent-runtime", "bogus"],
+  ]) {
+    const result = await invoke(args, { env: tools.env });
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, /--agent-runtime must name a built-in agent runtime/);
+  }
+  assert.deepEqual(await readCommandLog(tools.logFile), []);
+});
+
+test("an explicit --agent-runtime fails closed when the built image lacks the runtime env", async t => {
+  const tools = await fakeDeployTools(t, {
+    controller: "workflow-success",
+    localArchitecture: "arm64",
+  });
+  const args = deployArgs(tools.taskFile).filter((value, index, all) => (
+    value !== "--host" && all[index - 1] !== "--host"
+      && value !== "--image" && all[index - 1] !== "--image"
+  ));
+  args.push("--agent-runtime", "opencode");
+  const result = await invoke(args, { env: tools.env });
+
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /built image agent runtime unset does not match --agent-runtime opencode/);
+  const entries = await readCommandLog(tools.logFile);
+  assert.equal(entries.some(entry => entry.tool === "local-controller-envelope"), false);
+});
+
+test("an explicit --agent-runtime matching the built image env runs the controller", async t => {
+  const tools = await fakeDeployTools(t, {
+    controller: "workflow-success",
+    localArchitecture: "arm64",
+    localConfig: { ...BASE_CONFIG, Env: ["NODE_ENV=production", "BIMO_AGENT_RUNTIME=opencode"] },
+  });
+  const args = deployArgs(tools.taskFile).filter((value, index, all) => (
+    value !== "--host" && all[index - 1] !== "--host"
+      && value !== "--image" && all[index - 1] !== "--image"
+  ));
+  args.push("--agent-runtime", "opencode");
+  const result = await invoke(args, { env: tools.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  const response = JSON.parse(result.stdout);
+  assert.equal(response.template, "react-app");
+  const entries = await readCommandLog(tools.logFile);
+  const envelope = entries.find(entry => entry.tool === "local-controller-envelope");
+  assert.ok(envelope.fields.includes("agentRuntime"));
+});
+
 test("explicit SSH target builds for the target daemon architecture", async t => {
   const tools = await fakeDeployTools(t, {
     controller: "workflow-success",
@@ -786,7 +864,7 @@ test("organize transfers content-verified image without retagging and runs one e
 
   const organizerEnvelope = entries.find(entry => entry.tool === "organizer-envelope");
   assert.deepEqual(organizerEnvelope.fields, [
-    "agents", "deployment", "image", "key", "model", "prompt", "runId", "version",
+    "agentRuntime", "agents", "deployment", "image", "key", "model", "prompt", "runId", "version",
   ]);
   assert.equal(organizerEnvelope.deployment, "organizer-demo");
   assert.equal(organizerEnvelope.agents, 2);
@@ -896,12 +974,14 @@ test("internal-organize rejects exact envelope violations before Docker", async 
     agents: 1,
     key: `sk-or-v1-${"k".repeat(32)}`,
     model: "openrouter/deepseek/deepseek-v4-flash",
+    agentRuntime: "opencode",
     image: LOCAL_IMAGE_ID,
   };
   for (const [envelope, pattern] of [
     [{ ...base, extra: true }, /invalid shape|exactly/],
     [{ ...base, image: undefined }, /invalid shape|exactly/],
     [{ ...base, agents: 0 }, /controller envelope is invalid/],
+    [{ ...base, agentRuntime: "bogus" }, /controller envelope is invalid/],
   ]) {
     if (envelope.image === undefined) delete envelope.image;
     const result = await invoke([
@@ -945,6 +1025,7 @@ test("internal-run rejects an invalid or mismatched template digest before Docke
     task: "Build the application.",
     key: `sk-or-v1-${"k".repeat(32)}`,
     model: "openrouter/deepseek/deepseek-v4-flash",
+    agentRuntime: "opencode",
     image: LOCAL_IMAGE_ID,
     port: 8080,
     publicUrl: "http://example.invalid:8080",
@@ -975,6 +1056,7 @@ test("internal-pod-run rejects a mismatched packaged template before Git or Dock
     task: "Implement the fixed pod.",
     key: `sk-or-v1-${"k".repeat(32)}`,
     model: "openrouter/deepseek/deepseek-v4-flash",
+    agentRuntime: "opencode",
     image: LOCAL_IMAGE_ID,
     repository: "https://github.com/zaycruz/bimo.git",
     baseSha: POD_BASE_SHA,
@@ -1153,8 +1235,8 @@ test("pod deploy computes without GitHub authority then publishes one exact draf
   const computeEnvelope = entries.find(entry => entry.tool === "pod-compute-envelope");
   const publishEnvelope = entries.find(entry => entry.tool === "pod-publish-envelope");
   assert.deepEqual(computeEnvelope.fields, [
-    "baseSha", "deployment", "image", "key", "model", "repository", "runId", "targetBranch",
-    "task", "template", "templateDigest", "version",
+    "agentRuntime", "baseSha", "deployment", "image", "key", "model", "repository", "runId",
+    "targetBranch", "task", "template", "templateDigest", "version",
   ]);
   assert.deepEqual(publishEnvelope.fields, [
     "baseSha", "candidateSha", "headBranch", "repository", "runId", "targetBranch", "token", "version",

--- a/test/docker-runtime.test.mjs
+++ b/test/docker-runtime.test.mjs
@@ -176,6 +176,7 @@ test("agent containers use only the isolated agent network and external prompt m
 
   assert.match(rendered, /--network bimo-demo-agents/);
   assert.match(rendered, /BIMO_GATEWAY_URL=http:\/\/gateway:8787\/api\/v1/);
+  assert.match(rendered, /--env BIMO_AGENT_RUNTIME=opencode/);
   assert.match(rendered, /dst=\/workspace,readonly/);
   assert.match(rendered, /instructions\.md,dst=\/instructions\/instructions\.md,readonly/);
   assert.match(rendered, /--read-only/);
@@ -184,6 +185,29 @@ test("agent containers use only the isolated agent network and external prompt m
   assert.match(rendered, /--ulimit fsize=8388608:8388608/);
   assert.doesNotMatch(rendered, /--network container:|127\.0\.0\.1:8787|\.bimo-instructions/);
   assert.doesNotMatch(rendered, /OPENROUTER_API_KEY|sk-or-|docker\.sock|\/state|Users\/|\.ssh/);
+});
+
+test("agent containers pin the selected agent runtime next to the gateway env", () => {
+  const base = {
+    ...common,
+    role: "qa",
+    step: 2,
+    network: "bimo-demo-agents",
+    workspaceHost: "/var/lib/bimo/deployments/demo/workspace",
+    handoffHost: "/var/lib/bimo/deployments/demo/runs/run-1/attempts/qa/handoff",
+    promptHost: "/var/lib/bimo/deployments/demo/runs/run-1/attempts/qa/instructions.md",
+    access: "read",
+    model: "openrouter/deepseek/deepseek-v4-flash",
+    timeoutSeconds: 1200,
+  };
+  const args = agentCreateArgs({ ...base, agentRuntime: "opencode" });
+  const gatewayIndex = args.indexOf("BIMO_GATEWAY_URL=http://gateway:8787/api/v1");
+  assert.ok(gatewayIndex > 0);
+  assert.deepEqual(args.slice(gatewayIndex + 1, gatewayIndex + 3), [
+    "--env", "BIMO_AGENT_RUNTIME=opencode",
+  ]);
+  assert.throws(() => agentCreateArgs({ ...base, agentRuntime: "bogus" }), /unknown agent runtime/);
+  assert.throws(() => createRuntime({ agentRuntime: "bogus" }), /unknown agent runtime/);
 });
 
 test("only Engineering receives a writable shared workspace", () => {

--- a/test/organizer-controller.test.mjs
+++ b/test/organizer-controller.test.mjs
@@ -188,6 +188,7 @@ test("runs a majority organizer with read-only exact workspaces and durable comp
   assert.deepEqual(events.map(event => event.sequence), [1, 2]);
   assert.equal(events[0].agents, 3);
   assert.equal(events[0].model, MODEL);
+  assert.equal(events[0].agentRuntime, "unspecified");
   assert.equal(events[0].imageDigest, IMAGE_DIGEST);
   assert.equal(events[1].template, "react-app");
   assert.equal(events[1].templateDigest, CATALOG[0].templateDigest);

--- a/test/workflow.test.mjs
+++ b/test/workflow.test.mjs
@@ -232,6 +232,7 @@ test("a failed review loops through Engineering and leaves durable why history",
   assert.deepEqual(events.filter(event => event.type === "role.finished").map(event => event.outcome), [
     "completed", "failed", "completed", "passed", "passed",
   ]);
+  assert.equal(events[0].agentRuntime, "unspecified");
 
   const changelog = await readFile(path.join(locations.stateRoot, "run-a", "CHANGELOG.md"), "utf8");
   assert.match(changelog, /qa chose the smallest correct change/);


### PR DESCRIPTION
# Agent-runtime seam: close the opencode coupling

Bimo's guarantee contract was always runtime-agnostic — instructions at `/instructions/instructions.md`, bounded writes, `/handoff/result.json`, bounded output, role timeout, gateway-only network. But the agent CLI was hardwired to opencode in the Dockerfile, `src/agent.mjs`, and the CLI surface. This PR makes the agent runtime a closed registry — same philosophy as the deployment-target registry — with opencode as the only entry and **zero behavior change**. A follow-up (#44) adds pi behind this seam.

## What changed

- **`src/agent-runtime.mjs` (new)** — closed frozen registry. An adapter is exactly three operations: `spawnArgv({ model, role })`, `spawnEnv({ gateway })`, `createDiagnostics()`. `agentRuntimeFor(name)` fails closed on unknown names. The opencode adapter is the reference implementation (argv/env/diagnostics moved here verbatim).
- **`src/agent.mjs`** — now a thin dispatcher. Every cross-runtime guarantee stays here: gateway regex, detached kill-tree, 1 MiB output cap, sha256 receipt, timeout, handoff validation, prompt cap. Adapter results are shape-validated before spawn (bounded argv, `UPPER_SNAKE` env, diagnostics sink).
- **CLI** — `bimo deploy` / `bimo organize` accept `--agent-runtime NAME` (default `opencode`). Without `--image`, the default tag derives from the runtime (`bimo-workflow:0.6.0` for opencode, unchanged).
- **Image** — Dockerfile restructured into `base` + `runtime-opencode` stages; final stage is `runtime-${AGENT_RUNTIME}` (build-arg, default opencode). The runtime stage stamps `ENV BIMO_AGENT_RUNTIME=opencode`. `prepareImage` passes `--build-arg AGENT_RUNTIME=<name>` and fails closed unless the built image's `Config.Env` carries the matching stamp (a defaulted flag accepts pre-stamp images, so old images keep working).
- **Envelopes** — all three run envelopes (workflow, pod, organizer) carry `agentRuntime` as exact-shape validated data; controllers validate against the registry and pass it to every agent container as `BIMO_AGENT_RUNTIME`. `run.started` events record it next to model and image digest.
- **Docs** — new `docs/agent-runtimes.md` (adapter contract + non-weakenable invariants + why this is not a plugin system), README "Agent runtimes" section, AGENTS.md design-docs list.

Templates, roles, and organizer votes can never choose an agent runtime — selection is operator-only, same authority rule as images and targets.

## Verification

- `npm test` — 282 pass (271 existing + 11 new)
- `node --check` over `bin/bimo src/*.mjs test/*.mjs` — clean
- `npm pack --dry-run` — 60 files, includes new module + doc
- Real `docker build --build-arg AGENT_RUNTIME=opencode` — succeeds; image carries `BIMO_AGENT_RUNTIME=opencode` and opencode 1.18.23
- End-to-end `react-solo` deploy from this branch — see PR comment

## Out of scope

The `openrouter/...` model regex stays: it is the credential proxy's provider constraint, orthogonal to the agent runtime. Read-only commands (`logs`, `runs`, `status`, `cancel`, `publish`) do not take `--agent-runtime`; they launch no agents (pass `--image` when using a non-default runtime image).
