### PR TITLE
pi agent runtime (second registry entry)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,3 +13,6 @@
 !etc/organizer/organizer.md
 !etc/opencode/
 !etc/opencode/opencode.json
+!etc/pi/
+!etc/pi/models.json
+!etc/pi/settings.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ All three must pass before opening a PR, including for docs-only changes.
   runtime contract a second adapter must satisfy, and the security
   invariants it may not weaken.
 - [docs/agent-runtimes.md](docs/agent-runtimes.md) — the closed
-  agent-runtime registry (`opencode`), the adapter contract a second
+  agent-runtime registry (`opencode`, `pi`), the adapter contract a third
   agent runtime must satisfy, and the invariants it may not weaken.
 - [docs/templates.md](docs/templates.md) — the data-only template
   boundary: manifest schema, digest binding, customization path, and

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,27 @@ ENV OPENCODE_CONFIG=/etc/opencode/opencode.json \
 RUN chmod 0555 /etc/opencode \
     && chown -R root:root /etc/opencode
 
+FROM base AS runtime-pi
+
+ARG PI_VERSION=0.84.3
+
+# @earendil-works/pi-coding-agent@0.84.3 dist integrity:
+# sha512-Yr2p9PubrbFZmYEPYI+C8KmZP9xlFuLDnAG64RtU0ZDgrdiXYWa+y7WGyJO5OlqPliOkVCMd9IzVszO3/t0D0w==
+RUN npm install --global --ignore-scripts "@earendil-works/pi-coding-agent@${PI_VERSION}" \
+    && test "$(pi --version)" = "${PI_VERSION}" \
+    && npm cache clean --force
+
+COPY --chown=root:root --chmod=0444 etc/pi/ /etc/pi/agent/
+
+ENV PI_CODING_AGENT_DIR=/etc/pi/agent \
+    BIMO_AGENT_RUNTIME=pi
+
+# pi writes a settings lock and an auth store next to its config, so the
+# agent dispatcher seeds this read-only config into the writable HOME tmpfs
+# at startup; the baked copy stays root-owned like the opencode config.
+RUN chmod 0555 /etc/pi /etc/pi/agent \
+    && chown -R root:root /etc/pi
+
 FROM runtime-${AGENT_RUNTIME} AS final
 
 USER node

--- a/README.md
+++ b/README.md
@@ -161,11 +161,12 @@ this is deliberately not a plugin system yet.
 ## Agent runtimes
 
 The agent CLI a role container spawns is selected from a closed registry —
-one entry today:
+two entries today:
 
 | Runtime | Agent CLI | Default image tag | Selection |
 | --- | --- | --- | --- |
 | `opencode` | `opencode run` (pinned in the image) | `bimo-workflow:0.6.0` | Default, or `--agent-runtime opencode` |
+| `pi` | `pi -p` (pinned `@earendil-works/pi-coding-agent` in the image) | `bimo-workflow:0.6.0-pi` | `--agent-runtime pi` |
 
 `bimo deploy` and `bimo organize` accept `--agent-runtime NAME`. The name is
 validated against the registry, baked into the image with
@@ -175,9 +176,12 @@ the role timeout, the kill-tree, the gateway-only network, and the
 `/handoff/result.json` contract are enforced by the dispatcher and are
 identical for every runtime. Without `--image`, the default tag is
 `bimo-workflow:0.6.0` for `opencode` and `bimo-workflow:0.6.0-<name>` for any
-future entry.
+other entry. With `pi`, `--model` keeps the usual `openrouter/<id>` form —
+the adapter maps it to the image's `bimo-gateway` provider, and pi accepts
+ids beyond the declared list (the declaration pins context-window metadata
+for the default model).
 [The agent runtime contract](docs/agent-runtimes.md) defines the adapter
-shape, the invariants a second runtime may not weaken, and why the registry
+shape, the invariants every runtime may not weaken, and why the registry
 is deliberately not a plugin system.
 
 ## Templates

--- a/docs/agent-runtimes.md
+++ b/docs/agent-runtimes.md
@@ -10,9 +10,10 @@ The registry in `src/agent-runtime.mjs` is deliberately closed:
 | Runtime | Agent CLI | Default image tag | Selection |
 | --- | --- | --- | --- |
 | `opencode` | `opencode run` (pinned `opencode-ai` in the image) | `bimo-workflow:0.6.0` | Default, or `--agent-runtime opencode` |
+| `pi` | `pi -p` (pinned `@earendil-works/pi-coding-agent` in the image) | `bimo-workflow:0.6.0-pi` | `--agent-runtime pi` |
 
-`opencode` is the only entry today. This document defines the adapter
-contract a second runtime must satisfy. It exists so the runtime set grows by
+Two entries exist. This document defines the adapter
+contract every runtime must satisfy. It exists so the runtime set grows by
 evidence, not by adding a plugin system — the same rule
 [docs/targets.md](targets.md) sets for placement and
 [docs/runtime-contract.md](runtime-contract.md) sets for the execution
@@ -40,11 +41,47 @@ discovery, and no way to name a runtime that is not built in.
    never replay agent output content — event counts, byte totals, and an
    extracted HTTP status, never model text or secrets.
 
+An adapter may also declare an optional **`seedConfig`** — `{ source,
+target }` — when its config must be writable at run time. The dispatcher
+copies the baked read-only `source` (under `/etc/`) into the writable HOME
+tmpfs `target` (under `/home/node/`) before spawn, with the usual bounds:
+no symlinks, regular files only, bounded file count, size, and depth.
+
 That is the whole contract. The opencode adapter is the reference
 implementation: its argv pins `opencode run --pure --auto` against the
 mounted instructions file, its environment carries `OPENCODE_CONFIG`, and its
 diagnostics parse the opencode JSON event stream
 (`createOpenCodeDiagnostics`).
+
+The pi adapter follows the same shape with a few runtime-specific facts:
+
+- pi has no `--dir` or `--file` flags. The instructions attach as an
+  `@/instructions/instructions.md` message argument, and the working
+  directory comes from the agent container's `--workdir /workspace` create
+  argument (the image `WORKDIR` is `/app`), which the dispatcher's spawn
+  inherits.
+- Bimo model ids are `openrouter/<rest>`; pi resolves the provider on the
+  first slash, so the adapter maps the id to `bimo-gateway/<rest>`. The
+  shipped `etc/pi/models.json` declares the `bimo-gateway` provider against
+  the gateway URL. pi accepts model ids that are not declared there (it
+  warns and uses the id verbatim), so `--model` is not constrained to the
+  declared list; the declaration exists to pin context-window metadata for
+  the default model.
+- Stock pi has no permission guards, and its `--approval-mode`/`--yolo`
+  flags come from an extension the image does not load — the adapter passes
+  neither. The sandbox comes from the container topology, identical for
+  every runtime.
+- pi writes a settings lock and an auth store next to its config, and the
+  agent container's root filesystem is read-only. The adapter declares
+  `seedConfig`, so the dispatcher copies the baked root-owned
+  `/etc/pi/agent/` config into the writable `/home/node/.pi/agent/` tmpfs
+  before spawn and points `PI_CODING_AGENT_DIR` at the writable copy.
+- pi can exit 0 on a provider failure: the error surfaces as a `turn_end`
+  event whose `message.stopReason` is `"error"` and whose
+  `message.errorMessage` carries the HTTP status as a leading `NNN:` prefix.
+  `createPiDiagnostics` extracts that status; when pi exits 0 anyway, the
+  dispatcher's handoff check backstops the failure (no
+  `/handoff/result.json`, so the role fails closed).
 
 ## Invariants an adapter may not weaken
 
@@ -90,6 +127,9 @@ packages, the Bimo sources, the React starter layer, the bundled Docker CLI)
 plus one `runtime-<name>` stage per registry entry. The `runtime-opencode`
 stage installs the pinned `opencode-ai` version, copies
 `etc/opencode/opencode.json`, and stamps `ENV BIMO_AGENT_RUNTIME=opencode`;
+the `runtime-pi` stage installs the pinned `@earendil-works/pi-coding-agent`
+version, copies `etc/pi/` root-owned and read-only to `/etc/pi/agent/`, and
+stamps `ENV BIMO_AGENT_RUNTIME=pi`;
 the final stage is `runtime-${AGENT_RUNTIME}`. `prepareImage` passes
 `--build-arg AGENT_RUNTIME=<name>` and, after building, fails closed unless
 the image's `Config.Env` carries the matching `BIMO_AGENT_RUNTIME` — with one
@@ -99,18 +139,20 @@ selects `opencode` and produces the same behavior as the pre-staged image.
 
 When `--image` is not passed, the default tag derives from the runtime:
 `bimo-workflow:0.6.0` for `opencode` (unchanged), and
-`bimo-workflow:0.6.0-<name>` for any future entry. Read commands (`logs`,
+`bimo-workflow:0.6.0-<name>` for any other entry (`bimo-workflow:0.6.0-pi`
+for `pi`). Read commands (`logs`,
 `runs`, `status`, `cancel`, `publish`) do not launch agents; with a
 non-default runtime image, pass `--image` explicitly to them.
 
 ## Why this is not a plugin system
 
-One runtime exists. Loading arbitrary executable agent plugins now would
+Two runtimes exist. Loading arbitrary executable agent plugins now would
 require a versioned ABI, discovery rules, trust and signing policy, secret
 routing, and failure cleanup without adding a new capability — and it would
 hand templates and organizers a way to smuggle in executables, which the
-operator-only authority rule forbids. When a second agent runtime is
-implemented, it lands as a built-in entry behind this registry, satisfying
-the same contract and invariants. If two or more external runtimes then need
+operator-only authority rule forbids. The second agent runtime landed as a
+built-in entry behind this registry, satisfying the same contract and
+invariants; any further entry does the same. If two or more external
+runtimes then need
 independent release cycles, the registry can become a versioned plugin
 boundary with evidence instead of speculation.

--- a/etc/pi/models.json
+++ b/etc/pi/models.json
@@ -1,0 +1,18 @@
+{
+  "providers": {
+    "bimo-gateway": {
+      "name": "Bimo Gateway",
+      "baseUrl": "http://gateway:8787/api/v1",
+      "api": "openai-completions",
+      "apiKey": "bimo-runtime-proxy",
+      "models": [
+        {
+          "id": "deepseek/deepseek-v4-flash",
+          "name": "DeepSeek V4 Flash (via gateway)",
+          "contextWindow": 131072,
+          "maxTokens": 8192
+        }
+      ]
+    }
+  }
+}

--- a/etc/pi/settings.json
+++ b/etc/pi/settings.json
@@ -1,0 +1,5 @@
+{
+  "quietStartup": true,
+  "defaultProjectTrust": "never",
+  "enableInstallTelemetry": false
+}

--- a/src/agent-runtime.mjs
+++ b/src/agent-runtime.mjs
@@ -10,6 +10,23 @@ const DIAGNOSTIC_EVENT_TYPES = new Set([
   "text",
   "tool_use",
 ]);
+const PI_DIAGNOSTIC_EVENT_TYPES = new Set([
+  "agent_end",
+  "agent_settled",
+  "agent_start",
+  "auto_retry_end",
+  "auto_retry_start",
+  "error",
+  "message_end",
+  "message_start",
+  "message_update",
+  "session",
+  "tool_execution_end",
+  "tool_execution_start",
+  "tool_execution_update",
+  "turn_end",
+  "turn_start",
+]);
 
 export const AGENT_INSTRUCTIONS_PATH = "/instructions/instructions.md";
 export const DEFAULT_AGENT_RUNTIME = "opencode";
@@ -98,6 +115,80 @@ export function createOpenCodeDiagnostics() {
   };
 }
 
+// pi can exit 0 on a provider failure: the error surfaces as a turn_end
+// event whose message.stopReason is "error" and whose message.errorMessage
+// carries the HTTP status as a leading "NNN:" prefix. failure() is only
+// reached on a non-zero exit; for the exit-0 case the dispatcher's handoff
+// check backstops the failure (no /handoff/result.json fails the role).
+export function createPiDiagnostics() {
+  let stdoutBytes = 0;
+  let stderrBytes = 0;
+  let stdoutLine = "";
+  let discardingLine = false;
+  let finished = false;
+  const decoder = new TextDecoder("utf-8");
+  const eventCounts = new Map();
+  let errorStatus = null;
+  const recordEvent = line => {
+    if (!line || Buffer.byteLength(line) > MAX_DIAGNOSTIC_LINE_BYTES) return;
+    let event;
+    try {
+      event = JSON.parse(line);
+    } catch {
+      return;
+    }
+    if (!event || typeof event !== "object" || Array.isArray(event)
+        || !PI_DIAGNOSTIC_EVENT_TYPES.has(event.type)) return;
+    eventCounts.set(event.type, (eventCounts.get(event.type) ?? 0) + 1);
+    const message = event.message;
+    if (message && typeof message === "object" && !Array.isArray(message)
+        && message.stopReason === "error" && typeof message.errorMessage === "string") {
+      const match = /^(\d{3})\b/u.exec(message.errorMessage);
+      if (match) errorStatus = Number(match[1]);
+    }
+  };
+  return {
+    stdout(chunk) {
+      stdoutBytes += chunk.length;
+      let text = decoder.decode(chunk, { stream: true });
+      if (discardingLine) {
+        const newline = text.indexOf("\n");
+        if (newline === -1) return;
+        discardingLine = false;
+        text = text.slice(newline + 1);
+      }
+      const lines = `${stdoutLine}${text}`.split("\n");
+      stdoutLine = lines.pop() ?? "";
+      for (const line of lines) recordEvent(line);
+      if (Buffer.byteLength(stdoutLine) > MAX_DIAGNOSTIC_LINE_BYTES) {
+        stdoutLine = "";
+        discardingLine = true;
+      }
+    },
+    stderr(chunk) {
+      stderrBytes += chunk.length;
+    },
+    failure(code) {
+      if (finished) throw new Error("pi diagnostics already finalized");
+      finished = true;
+      const finalLine = discardingLine ? "" : `${stdoutLine}${decoder.decode()}`;
+      if (finalLine) recordEvent(finalLine);
+      const exit = Number.isInteger(code) ? `agent exited ${code}` : "agent exited on signal";
+      const events = [...eventCounts.entries()]
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([type, count]) => `${type}:${count}`)
+        .join(",");
+      return [
+        exit,
+        ...(events ? [`events=${events}`] : []),
+        ...(errorStatus === null ? [] : [`errorStatus=${errorStatus}`]),
+        `stdoutBytes=${stdoutBytes}`,
+        `stderrBytes=${stderrBytes}`,
+      ].join("; ");
+    },
+  };
+}
+
 const AGENT_RUNTIMES = Object.freeze({
   opencode: Object.freeze({
     name: "opencode",
@@ -128,6 +219,50 @@ const AGENT_RUNTIMES = Object.freeze({
       };
     },
     createDiagnostics: createOpenCodeDiagnostics,
+  }),
+  pi: Object.freeze({
+    name: "pi",
+    spawnArgv({ model }) {
+      return [
+        "pi",
+        "-p",
+        "--mode", "json",
+        "--no-session",
+        "--no-extensions",
+        "--no-skills",
+        "--no-prompt-templates",
+        "--no-themes",
+        "--no-context-files",
+        "--tools", "read,write,edit,bash,grep,find,ls",
+        // Bimo model ids are openrouter/<rest>; pi resolves the provider on
+        // the first slash and the shipped provider is named bimo-gateway.
+        "--model", model.replace(/^openrouter\//u, "bimo-gateway/"),
+        // pi has no --file flag; instructions attach as an @file message.
+        `@${AGENT_INSTRUCTIONS_PATH}`,
+        "Follow the attached Bimo instructions exactly.",
+      ];
+    },
+    spawnEnv({ gateway }) {
+      return {
+        PATH: process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin",
+        HOME: "/home/node",
+        TMPDIR: "/tmp",
+        LANG: "C.UTF-8",
+        CI: "1",
+        PI_OFFLINE: "1",
+        // pi writes a settings lock and an auth store next to its config,
+        // and the container root filesystem is read-only: the dispatcher
+        // seeds the baked /etc/pi/agent config into the writable HOME
+        // tmpfs (seedConfig below) and pi uses the writable copy.
+        PI_CODING_AGENT_DIR: "/home/node/.pi/agent",
+        BIMO_GATEWAY_URL: gateway,
+      };
+    },
+    seedConfig: Object.freeze({
+      source: "/etc/pi/agent",
+      target: "/home/node/.pi/agent",
+    }),
+    createDiagnostics: createPiDiagnostics,
   }),
 });
 

--- a/src/agent.mjs
+++ b/src/agent.mjs
@@ -2,7 +2,7 @@
 
 import { createHash } from "node:crypto";
 import { spawn } from "node:child_process";
-import { lstat, readFile, unlink } from "node:fs/promises";
+import { lstat, mkdir, readFile, readdir, unlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
 import { pathToFileURL } from "node:url";
@@ -65,6 +65,55 @@ function assertDiagnostics(diagnostics) {
     fail("agent runtime returned invalid diagnostics");
   }
   return diagnostics;
+}
+
+// A runtime whose config must be writable at run time (pi writes a settings
+// lock and an auth store next to its config) declares seedConfig: the
+// dispatcher copies the baked read-only config into the writable HOME tmpfs
+// before spawn. Bounds keep the seed as strict as every other read.
+const SEED_SOURCE = /^\/etc\/[a-z0-9][a-z0-9/-]{0,63}$/;
+const SEED_TARGET = /^\/home\/node\/[a-z0-9.][a-z0-9./-]{0,63}$/;
+const MAX_SEED_FILES = 16;
+const MAX_SEED_FILE_BYTES = 65_536;
+const MAX_SEED_TOTAL_BYTES = 1_048_576;
+const MAX_SEED_DEPTH = 4;
+
+export function assertSeedConfig(seed) {
+  if (seed === undefined || seed === null) return null;
+  if (typeof seed !== "object" || Array.isArray(seed)
+      || !SEED_SOURCE.test(seed.source ?? "") || !SEED_TARGET.test(seed.target ?? "")
+      || seed.target.includes("..")) {
+    fail("agent runtime returned an invalid seed config");
+  }
+  return Object.freeze({ source: seed.source, target: seed.target });
+}
+
+export async function seedAgentConfig(seed) {
+  if (seed === null) return;
+  let files = 0;
+  let totalBytes = 0;
+  const copy = async (source, target, depth) => {
+    if (depth > MAX_SEED_DEPTH) fail("agent runtime seed config is too deep");
+    const stat = await lstat(source);
+    if (stat.isSymbolicLink()) fail("agent runtime seed config must not contain symlinks");
+    if (stat.isDirectory()) {
+      await mkdir(target, { recursive: true });
+      for (const entry of await readdir(source)) {
+        await copy(path.join(source, entry), path.join(target, entry), depth + 1);
+      }
+      return;
+    }
+    if (!stat.isFile()) fail("agent runtime seed config must contain only regular files");
+    files += 1;
+    totalBytes += stat.size;
+    if (files > MAX_SEED_FILES || stat.size > MAX_SEED_FILE_BYTES
+        || totalBytes > MAX_SEED_TOTAL_BYTES) {
+      fail("agent runtime seed config exceeds its bounds");
+    }
+    await mkdir(path.dirname(target), { recursive: true });
+    await writeFile(target, await readFile(source));
+  };
+  await copy(seed.source, seed.target, 1);
 }
 
 function runAgent(runtime, { model, timeoutSeconds, role }) {
@@ -142,6 +191,7 @@ async function main() {
   const existing = await lstat("/handoff/result.json").catch(() => null);
   if (existing) await unlink("/handoff/result.json");
 
+  await seedAgentConfig(assertSeedConfig(runtime.seedConfig));
   const result = await runAgent(runtime, options);
   const handoff = await lstat("/handoff/result.json").catch(() => null);
   if (!handoff?.isFile() || handoff.isSymbolicLink() || handoff.size < 2 || handoff.size > 65_536) {

--- a/src/docker-runtime.mjs
+++ b/src/docker-runtime.mjs
@@ -280,6 +280,9 @@ export function agentCreateArgs({
     "--tmpfs", "/tmp:rw,nosuid,nodev,size=512m",
     "--tmpfs", "/home/node:rw,nosuid,nodev,size=512m,uid=1000,gid=1000",
     "--tmpfs", "/instructions:rw,nosuid,nodev,noexec,size=64k,uid=1000,gid=1000",
+    // The image WORKDIR is /app; agent runtimes without a --dir flag (pi)
+    // inherit the process cwd, so pin it to the mounted workspace.
+    "--workdir", "/workspace",
     "--env", "BIMO_GATEWAY_URL=http://gateway:8787/api/v1",
     "--env", `BIMO_AGENT_RUNTIME=${agentRuntime}`,
     "--mount", bind(workspaceHost, "/workspace", workspaceMounts.rootReadOnly),

--- a/test/agent-runtime.test.mjs
+++ b/test/agent-runtime.test.mjs
@@ -7,16 +7,21 @@ import {
   DEFAULT_AGENT_RUNTIME,
   agentRuntimeFor,
   createOpenCodeDiagnostics,
+  createPiDiagnostics,
 } from "../src/agent-runtime.mjs";
 
 test("the agent runtime registry is closed, frozen, and defaults to opencode", () => {
-  assert.deepEqual([...AGENT_RUNTIME_NAMES], ["opencode"]);
+  assert.deepEqual([...AGENT_RUNTIME_NAMES], ["opencode", "pi"]);
   assert.ok(Object.isFrozen(AGENT_RUNTIME_NAMES));
   assert.equal(DEFAULT_AGENT_RUNTIME, "opencode");
   const runtime = agentRuntimeFor("opencode");
   assert.equal(runtime.name, "opencode");
   assert.ok(Object.isFrozen(runtime));
   assert.equal(agentRuntimeFor("opencode"), runtime);
+  const pi = agentRuntimeFor("pi");
+  assert.equal(pi.name, "pi");
+  assert.ok(Object.isFrozen(pi));
+  assert.equal(agentRuntimeFor("pi"), pi);
 });
 
 test("unknown or malformed runtime names fail closed", () => {
@@ -80,4 +85,97 @@ test("opencode diagnostics count bounded JSON events without leaking content", (
   assert.doesNotMatch(summary, /hidden/u);
 
   assert.throws(() => diagnostics.failure(1), /already finalized/);
+});
+
+test("the pi adapter builds the exact bounded spawn argv with the gateway model mapping", () => {
+  const argv = agentRuntimeFor("pi").spawnArgv({
+    model: "openrouter/deepseek/deepseek-v4-flash",
+    role: "qa",
+  });
+  assert.deepEqual(argv, [
+    "pi",
+    "-p",
+    "--mode", "json",
+    "--no-session",
+    "--no-extensions",
+    "--no-skills",
+    "--no-prompt-templates",
+    "--no-themes",
+    "--no-context-files",
+    "--tools", "read,write,edit,bash,grep,find,ls",
+    "--model", "bimo-gateway/deepseek/deepseek-v4-flash",
+    `@${AGENT_INSTRUCTIONS_PATH}`,
+    "Follow the attached Bimo instructions exactly.",
+  ]);
+});
+
+test("the pi adapter exposes only the bounded spawn environment", () => {
+  const runtime = agentRuntimeFor("pi");
+  const env = runtime.spawnEnv({ gateway: "http://gateway:8787/api/v1" });
+  assert.deepEqual(Object.keys(env).sort(), [
+    "BIMO_GATEWAY_URL", "CI", "HOME", "LANG", "PATH",
+    "PI_CODING_AGENT_DIR", "PI_OFFLINE", "TMPDIR",
+  ]);
+  assert.equal(env.BIMO_GATEWAY_URL, "http://gateway:8787/api/v1");
+  assert.equal(env.PI_OFFLINE, "1");
+  assert.equal(env.PI_CODING_AGENT_DIR, "/home/node/.pi/agent");
+  assert.equal(env.HOME, "/home/node");
+  assert.ok(env.PATH.length > 0);
+
+  env.BIMO_GATEWAY_URL = "http://attacker:1/api/v1";
+  const fresh = runtime.spawnEnv({ gateway: "http://gateway:8787/api/v1" });
+  assert.equal(fresh.BIMO_GATEWAY_URL, "http://gateway:8787/api/v1");
+});
+
+test("the pi adapter declares a frozen bounded seed config", () => {
+  const runtime = agentRuntimeFor("pi");
+  assert.deepEqual(runtime.seedConfig, {
+    source: "/etc/pi/agent",
+    target: "/home/node/.pi/agent",
+  });
+  assert.ok(Object.isFrozen(runtime.seedConfig));
+  assert.equal(agentRuntimeFor("opencode").seedConfig, undefined);
+});
+
+test("pi diagnostics count bounded JSON events without leaking content", () => {
+  const diagnostics = createPiDiagnostics();
+  diagnostics.stdout(Buffer.from([
+    '{"type":"session","id":"abc"}',
+    '{"type":"agent_start"}',
+    '{"type":"turn_start"}',
+    '{"type":"tool_execution_start","toolName":"bash"}',
+    '{"type":"message_update","delta":"hidden model text"}',
+    '{"type":"turn_end","message":{"stopReason":"error","errorMessage":"401: {\\"error\\":\\"unauthorized sk-hidden\\"}"}}',
+    "",
+  ].join("\n")));
+  diagnostics.stderr(Buffer.from("raw sk-hidden"));
+
+  const summary = diagnostics.failure(1);
+  assert.match(summary, /^agent exited 1; /u);
+  assert.match(summary, /events=agent_start:1,message_update:1,session:1,tool_execution_start:1,turn_end:1,turn_start:1/u);
+  assert.match(summary, /errorStatus=401/u);
+  assert.match(summary, /stderrBytes=13$/u);
+  assert.doesNotMatch(summary, /hidden/u);
+
+  assert.throws(() => diagnostics.failure(1), /already finalized/);
+});
+
+test("pi diagnostics ignore undeclared event types and unbounded lines", () => {
+  const diagnostics = createPiDiagnostics();
+  diagnostics.stdout(Buffer.from('{"type":"bogus_custom"}\nnot json\n'));
+  diagnostics.stdout(Buffer.from(`${"x".repeat(70_000)}\n{"type":"agent_end"}`));
+
+  const summary = diagnostics.failure(null);
+  assert.match(summary, /^agent exited on signal; /u);
+  assert.match(summary, /events=agent_end:1/u);
+  assert.doesNotMatch(summary, /errorStatus/u);
+});
+
+test("pi diagnostics surface no errorStatus for turns that stop normally", () => {
+  const diagnostics = createPiDiagnostics();
+  diagnostics.stdout(Buffer.from('{"type":"turn_end","message":{"stopReason":"stop"}}\n'));
+
+  const summary = diagnostics.failure(2);
+  assert.match(summary, /events=turn_end:1/u);
+  assert.doesNotMatch(summary, /errorStatus/u);
 });

--- a/test/agent.test.mjs
+++ b/test/agent.test.mjs
@@ -1,10 +1,13 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
+import { mkdtemp, mkdir, readFile, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 import { createOpenCodeDiagnostics } from "../src/agent-runtime.mjs";
+import { assertSeedConfig, seedAgentConfig } from "../src/agent.mjs";
 
 const bimoScript = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -69,5 +72,48 @@ test("the agent entrypoint rejects an unknown BIMO_AGENT_RUNTIME before any work
   assert.equal(
     Buffer.concat(stderr).toString("utf8"),
     "bimo-agent: unknown agent runtime: bogus\n",
+  );
+});
+
+test("seed config validation accepts only baked /etc sources into the HOME tmpfs", () => {
+  assert.equal(assertSeedConfig(null), null);
+  assert.equal(assertSeedConfig(undefined), null);
+  const seed = assertSeedConfig({
+    source: "/etc/pi/agent",
+    target: "/home/node/.pi/agent",
+  });
+  assert.deepEqual(seed, { source: "/etc/pi/agent", target: "/home/node/.pi/agent" });
+  assert.ok(Object.isFrozen(seed));
+  for (const invalid of [
+    { source: "/workspace/pi", target: "/home/node/.pi/agent" },
+    { source: "/etc/pi/agent", target: "/etc/pi/agent" },
+    { source: "/etc/pi/agent", target: "/tmp/pi" },
+    { source: "/etc/pi/agent", target: "/home/node/../etc" },
+    { source: "/etc/../etc/pi", target: "/home/node/.pi/agent" },
+    { source: "/etc/pi/agent" },
+    "seed",
+  ]) {
+    assert.throws(() => assertSeedConfig(invalid), /invalid seed config/u);
+  }
+});
+
+test("seedAgentConfig copies bounded regular files and rejects symlinks", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "bimo-seed-"));
+  const source = path.join(root, "source");
+  const target = path.join(root, "home", ".pi", "agent");
+  await mkdir(path.join(source, "nested"), { recursive: true });
+  await writeFile(path.join(source, "models.json"), "{}");
+  await writeFile(path.join(source, "nested", "settings.json"), '{"a":1}');
+
+  await seedAgentConfig({ source, target });
+  const seeded = await readFile(path.join(target, "nested", "settings.json"), "utf8");
+  assert.equal(seeded, '{"a":1}');
+
+  await seedAgentConfig(null);
+
+  await symlink(path.join(source, "models.json"), path.join(source, "link"));
+  await assert.rejects(
+    seedAgentConfig({ source, target }),
+    /must not contain symlinks/u,
   );
 });

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -660,6 +660,48 @@ test("deploy and organize reject an unknown --agent-runtime before any Docker wo
   assert.deepEqual(await readCommandLog(tools.logFile), []);
 });
 
+test("deploy and organize accept --agent-runtime pi and derive the pi image tag", async t => {
+  const piConfig = { ...BASE_CONFIG, Env: ["NODE_ENV=production", "BIMO_AGENT_RUNTIME=pi"] };
+
+  const deployTools = await fakeDeployTools(t, {
+    controller: "workflow-success",
+    localArchitecture: "arm64",
+    localConfig: piConfig,
+  });
+  const deploy = deployArgs(deployTools.taskFile).filter((value, index, all) => (
+    value !== "--host" && all[index - 1] !== "--host"
+      && value !== "--image" && all[index - 1] !== "--image"
+  ));
+  deploy.push("--agent-runtime", "pi");
+  const deployResult = await invoke(deploy, { env: deployTools.env });
+  assert.equal(deployResult.code, 0, deployResult.stderr);
+  const deployEntries = await readCommandLog(deployTools.logFile);
+  const deployDocker = deployEntries.filter(entry => entry.tool === "docker").map(entry => entry.args);
+  const build = deployDocker.find(command => command[0] === "build");
+  assert.ok(build);
+  assert.equal(build[build.indexOf("--tag") + 1], "bimo-workflow:0.6.0-pi");
+  assert.equal(build[build.indexOf("--build-arg") + 1], "AGENT_RUNTIME=pi");
+  const deployEnvelope = deployEntries.find(entry => entry.tool === "local-controller-envelope");
+  assert.ok(deployEnvelope.fields.includes("agentRuntime"));
+
+  const organizeTools = await fakeDeployTools(t, {
+    controller: "organize-success",
+    localConfig: piConfig,
+    remoteConfig: { ...REORDERED_CONFIG, Env: ["NODE_ENV=production", "BIMO_AGENT_RUNTIME=pi"] },
+  });
+  const organize = organizeArgs("Build a small status page.", 1).filter((value, index, all) => (
+    value !== "--image" && all[index - 1] !== "--image"
+  ));
+  organize.push("--agent-runtime", "pi");
+  const organizeResult = await invoke(organize, { env: organizeTools.env });
+  assert.equal(organizeResult.code, 0, organizeResult.stderr);
+  const organizeEntries = await readCommandLog(organizeTools.logFile);
+  const organizeDocker = organizeEntries.filter(entry => entry.tool === "docker").map(entry => entry.args);
+  const organizeBuild = organizeDocker.find(command => command[0] === "build");
+  assert.ok(organizeBuild);
+  assert.equal(organizeBuild[organizeBuild.indexOf("--tag") + 1], "bimo-workflow:0.6.0-pi");
+});
+
 test("an explicit --agent-runtime fails closed when the built image lacks the runtime env", async t => {
   const tools = await fakeDeployTools(t, {
     controller: "workflow-success",

--- a/test/docker-runtime.test.mjs
+++ b/test/docker-runtime.test.mjs
@@ -175,6 +175,7 @@ test("agent containers use only the isolated agent network and external prompt m
   const rendered = args.join(" ");
 
   assert.match(rendered, /--network bimo-demo-agents/);
+  assert.match(rendered, /--workdir \/workspace/);
   assert.match(rendered, /BIMO_GATEWAY_URL=http:\/\/gateway:8787\/api\/v1/);
   assert.match(rendered, /--env BIMO_AGENT_RUNTIME=opencode/);
   assert.match(rendered, /dst=\/workspace,readonly/);
@@ -206,6 +207,8 @@ test("agent containers pin the selected agent runtime next to the gateway env", 
   assert.deepEqual(args.slice(gatewayIndex + 1, gatewayIndex + 3), [
     "--env", "BIMO_AGENT_RUNTIME=opencode",
   ]);
+  const piArgs = agentCreateArgs({ ...base, agentRuntime: "pi" });
+  assert.ok(piArgs.includes("BIMO_AGENT_RUNTIME=pi"));
   assert.throws(() => agentCreateArgs({ ...base, agentRuntime: "bogus" }), /unknown agent runtime/);
   assert.throws(() => createRuntime({ agentRuntime: "bogus" }), /unknown agent runtime/);
 });


### PR DESCRIPTION
feat: agent-runtime registry seam (opencode adapter) (#45)

Close the opencode coupling behind a closed agent-runtime registry,
mirroring the deployment-target registry philosophy. The adapter
contract is three operations (spawnArgv, spawnEnv, createDiagnostics);
every cross-runtime guarantee (bounded output, kill-tree, timeout,
handoff contract, gateway-only authority) stays in the dispatcher.

- src/agent-runtime.mjs: frozen registry, agentRuntimeFor fails closed
- src/agent.mjs: thin dispatcher with adapter shape validation
- CLI: --agent-runtime on deploy/organize, per-runtime image tags
- Dockerfile: base + runtime-opencode stages, AGENT_RUNTIME build-arg,
  image stamped with BIMO_AGENT_RUNTIME, prepareImage verifies the stamp
- envelopes carry agentRuntime as exact-shape validated data; agent
  containers receive it as BIMO_AGENT_RUNTIME; run.started records it
- docs/agent-runtimes.md + README section + AGENTS.md design docs

Zero behavior change: opencode remains the only entry and the default.
282 tests pass; react-solo parity deploy verified end to end.