### PR TITLE
Pod repository and target branch as operator inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,10 +504,15 @@ bimo deploy parallel-engineering-pod \
   --json
 ```
 
-The pod accepts only that repository and `main`. `--base-sha` must be the exact
-40-character commit currently expected at `main`; publication fails closed if
-the branch moves. The two secret references must resolve to separate,
-least-privilege credentials.
+`--repository` and `--target-branch` are operator inputs (they default to the
+Bimo repository and `main` when omitted). The pod works on any GitHub
+repository whose layout its verification profile understands: a Node.js
+project with sources under `src/`, baseline tests in `test/*.test.mjs`, and an
+`npm test` script. `--base-sha` must be the exact 40-character commit
+currently expected at the target branch; publication fails closed if the
+branch moves. The two secret references must resolve to separate,
+least-privilege credentials, and the GitHub token must have content and
+pull-request access to the target repository.
 
 Read the pod's structured events using the run ID returned by deploy:
 
@@ -592,8 +597,9 @@ The older `--host` and `--proxmox ... --vmid ...` forms remain aliases. Target
 options cannot be mixed. Deploy also accepts exactly one task source
 (`--task-file FILE` or `--task-stdin`). Every deployment
 requires `--deployment` and `--secret-ref`. Sequential workflows also require
-`--public-url`. The fixed pod instead requires `--github-secret-ref`, the fixed
-repository URL, an immutable `--base-sha`, and `--target-branch main`.
+`--public-url`. The pod instead requires `--github-secret-ref` and an immutable
+`--base-sha`; `--repository` and `--target-branch` are optional and default to
+the Bimo repository and `main`.
 
 Optional shared flags are `--account`, `--model`, `--image`, `--agent-runtime`,
 and `--json`; sequential deploys also accept `--port`. `logs` accepts `--run`,

--- a/src/bimo.mjs
+++ b/src/bimo.mjs
@@ -42,8 +42,9 @@ const templateRoot = path.join(packageRoot, "templates");
 const organizerInstructionsPath = path.join(packageRoot, "etc", "organizer", "organizer.md");
 const DEFAULT_IMAGE = "bimo-workflow:0.6.0";
 const DEFAULT_MODEL = "openrouter/deepseek/deepseek-v4-flash";
-const POD_REPOSITORY = "https://github.com/zaycruz/bimo.git";
-const POD_TARGET_BRANCH = "main";
+const DEFAULT_POD_REPOSITORY = "https://github.com/zaycruz/bimo.git";
+const DEFAULT_POD_TARGET_BRANCH = "main";
+const POD_REPOSITORY_URL = /^https:\/\/github\.com\/[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?\/[A-Za-z0-9._-]{1,100}(?:\.git)?$/;
 const PUBLISH_TIMEOUT_MS = 5 * 60 * 1_000;
 const IMAGE_TRANSFER_TIMEOUT_MS = 10 * 60 * 1_000;
 const NAME = /^[a-z][a-z0-9-]{0,31}$/;
@@ -858,6 +859,26 @@ function validateOrganizerPlan(value, expected) {
   return value;
 }
 
+function validPodRepository(value) {
+  if (!POD_REPOSITORY_URL.test(value ?? "")) return false;
+  const name = value.replace(/\.git$/, "").split("/").pop();
+  return name !== "." && name !== "..";
+}
+
+function validTargetBranch(value) {
+  if (typeof value !== "string" || value.length < 1 || value.length > 128) return false;
+  if (value.startsWith("/") || value.endsWith("/") || value.endsWith(".")
+      || value.startsWith("-")
+      || value.includes("//") || value.includes("..") || value.includes("@{")
+      || value === "@" || value.endsWith(".lock")) return false;
+  // git-check-ref-format: no control characters, space, or ~^:?*[\
+  return !/[\x00-\x20~^:?*[\\]/.test(value);
+}
+
+function podPullUrl(repository, number) {
+  return `${repository.replace(/\.git$/, "")}/pull/${number}`;
+}
+
 function validatePodReady(value, expected) {
   exactObject(value, ["status", "runId", "baseSha", "candidateSha", "branch"], "pod controller");
   if (value.status !== "ready" || value.runId !== expected.runId
@@ -874,7 +895,7 @@ function validatePublishedPod(value, expected) {
     "headBranch", "publication",
   ], "pod publisher");
   if (value.status !== "completed" || value.runId !== expected.runId
-      || value.repository !== POD_REPOSITORY || value.targetBranch !== POD_TARGET_BRANCH
+      || value.repository !== expected.repository || value.targetBranch !== expected.targetBranch
       || value.baseSha !== expected.baseSha || value.candidateSha !== expected.candidateSha
       || value.headBranch !== expected.branch) {
     fail("pod publisher returned an invalid completion receipt");
@@ -888,8 +909,8 @@ function validatePublishedPod(value, expected) {
       || !Number.isSafeInteger(publication.number) || publication.number < 1
       || publication.draft !== true || typeof publication.created !== "boolean"
       || publication.baseSha !== expected.baseSha || publication.headSha !== expected.candidateSha
-      || publication.headBranch !== expected.branch || publication.targetBranch !== POD_TARGET_BRANCH
-      || !new RegExp(`^https://github\\.com/zaycruz/bimo/pull/${publication.number}$`).test(publication.url ?? "")) {
+      || publication.headBranch !== expected.branch || publication.targetBranch !== expected.targetBranch
+      || publication.url !== podPullUrl(expected.repository, publication.number)) {
     fail("pod publisher returned an invalid draft pull request receipt");
   }
   return value;
@@ -919,10 +940,16 @@ async function deploy(template, options) {
   if (!/^openrouter\/[a-z0-9][a-z0-9._/-]{2,127}$/.test(model)) fail("--model is invalid");
   let port;
   let publicUrl;
+  let repository;
+  let targetBranch;
   if (pod) {
-    if (options.repository !== POD_REPOSITORY) fail(`--repository must be ${POD_REPOSITORY}`);
+    repository = options.repository ?? DEFAULT_POD_REPOSITORY;
+    if (!validPodRepository(repository)) {
+      fail("--repository must be an https github.com repository URL");
+    }
     if (!GIT_SHA.test(options["base-sha"] ?? "")) fail("--base-sha must be an exact 40-character Git SHA");
-    if (options["target-branch"] !== POD_TARGET_BRANCH) fail(`--target-branch must be ${POD_TARGET_BRANCH}`);
+    targetBranch = options["target-branch"] ?? DEFAULT_POD_TARGET_BRANCH;
+    if (!validTargetBranch(targetBranch)) fail("--target-branch is not a valid Git branch name");
     if (!options["github-secret-ref"]) fail("--github-secret-ref is required");
   } else {
     port = Number(options.port ?? 8080);
@@ -989,9 +1016,9 @@ async function deploy(template, options) {
         model,
         agentRuntime,
         image: remoteImage.imageId,
-        repository: POD_REPOSITORY,
+        repository,
         baseSha: options["base-sha"],
-        targetBranch: POD_TARGET_BRANCH,
+        targetBranch,
         runId,
       });
       openRouterKey = "";
@@ -1030,8 +1057,8 @@ async function deploy(template, options) {
       const publishEnvelope = JSON.stringify({
         version: 1,
         runId,
-        repository: POD_REPOSITORY,
-        targetBranch: POD_TARGET_BRANCH,
+        repository,
+        targetBranch,
         baseSha: ready.baseSha,
         candidateSha: ready.candidateSha,
         headBranch: ready.branch,
@@ -1060,7 +1087,11 @@ async function deploy(template, options) {
         timeoutMs: PUBLISH_TIMEOUT_MS + 60_000,
         maxOutputBytes: 512 * 1024,
       });
-      const response = validatePublishedPod(parseLastJson(publisher.stdout, "pod publisher"), ready);
+      const response = validatePublishedPod(parseLastJson(publisher.stdout, "pod publisher"), {
+        ...ready,
+        repository,
+        targetBranch,
+      });
       if (options.json) process.stdout.write(`${JSON.stringify(response)}\n`);
       else process.stdout.write(
         `deployed ${loaded.template.name} as ${options.deployment}\nrun: ${response.runId}\nPR: ${response.publication.url} (draft)\n`,
@@ -1522,8 +1553,8 @@ async function internalPodRun(options) {
       || !/^sk-or-v1-[A-Za-z0-9_-]{32,}$/.test(envelope.key ?? "")
       || !/^openrouter\/[a-z0-9][a-z0-9._/-]{2,127}$/.test(envelope.model ?? "")
       || !AGENT_RUNTIME_NAMES.includes(envelope.agentRuntime)
-      || !SHA256.test(envelope.image ?? "") || envelope.repository !== POD_REPOSITORY
-      || !GIT_SHA.test(envelope.baseSha ?? "") || envelope.targetBranch !== POD_TARGET_BRANCH
+      || !SHA256.test(envelope.image ?? "") || !validPodRepository(envelope.repository)
+      || !GIT_SHA.test(envelope.baseSha ?? "") || !validTargetBranch(envelope.targetBranch)
       || !RUN_ID.test(envelope.runId ?? "")) {
     fail("pod controller envelope is invalid");
   }
@@ -1535,7 +1566,7 @@ async function internalPodRun(options) {
     ([slot, writer]) => [slot, [...writer.allowedWriteRoots]],
   ));
   const source = new GitRuntime({
-    allowedRepositories: [POD_REPOSITORY],
+    allowedRepositories: [envelope.repository],
     allowedWriteRoots,
     gitRoot: "/source",
     worktreesRoot: "/worktrees",
@@ -1597,7 +1628,7 @@ async function internalPublish(options) {
     "headBranch", "token",
   ], "publisher");
   if (envelope.version !== 1 || !RUN_ID.test(envelope.runId ?? "")
-      || envelope.repository !== POD_REPOSITORY || envelope.targetBranch !== POD_TARGET_BRANCH
+      || !validPodRepository(envelope.repository) || !validTargetBranch(envelope.targetBranch)
       || !GIT_SHA.test(envelope.baseSha ?? "") || !GIT_SHA.test(envelope.candidateSha ?? "")
       || envelope.headBranch !== `bimo/${envelope.runId}`
       || !GITHUB_TOKEN.test(envelope.token ?? "")) {
@@ -1637,7 +1668,7 @@ async function internalPublishResume(options) {
   const ready = store.events.filter(event => event.type === "publication.ready");
   if (ready.length !== 1) fail(`no publication-ready record found for run ${runId}`);
   const { repository, targetBranch, baseSha, candidateSha, headBranch } = ready[0];
-  if (repository !== POD_REPOSITORY || targetBranch !== POD_TARGET_BRANCH
+  if (!validPodRepository(repository) || !validTargetBranch(targetBranch)
       || !GIT_SHA.test(baseSha ?? "") || !GIT_SHA.test(candidateSha ?? "")
       || headBranch !== `bimo/${runId}`) {
     fail("publication.ready record is invalid");
@@ -2199,7 +2230,7 @@ function validateResumedPublication(value) {
     "headBranch", "publication",
   ], "pod publisher");
   if (value.status !== "completed" || !RUN_ID.test(value.runId ?? "")
-      || value.repository !== POD_REPOSITORY || value.targetBranch !== POD_TARGET_BRANCH
+      || !validPodRepository(value.repository) || !validTargetBranch(value.targetBranch)
       || !GIT_SHA.test(value.baseSha ?? "") || !GIT_SHA.test(value.candidateSha ?? "")
       || value.headBranch !== `bimo/${value.runId}`) {
     fail("pod publisher returned an invalid completion receipt");
@@ -2213,8 +2244,8 @@ function validateResumedPublication(value) {
       || !Number.isSafeInteger(publication.number) || publication.number < 1
       || publication.draft !== true || typeof publication.created !== "boolean"
       || publication.baseSha !== value.baseSha || publication.headSha !== value.candidateSha
-      || publication.headBranch !== value.headBranch || publication.targetBranch !== POD_TARGET_BRANCH
-      || !new RegExp(`^https://github\\.com/zaycruz/bimo/pull/${publication.number}$`).test(publication.url ?? "")) {
+      || publication.headBranch !== value.headBranch || publication.targetBranch !== value.targetBranch
+      || publication.url !== podPullUrl(value.repository, publication.number)) {
     fail("pod publisher returned an invalid draft pull request receipt");
   }
   return value;
@@ -2575,7 +2606,7 @@ function usage() {
   bimo organize -p PROMPT [-n 1|2|3] --deployment NAME [--target local | --target ssh --host HOST | --target proxmox-lxc --proxmox HOST --vmid ID] --secret-ref op://VAULT/ITEM/FIELD [--json]
   bimo -p PROMPT [-n 1|2|3] --deployment NAME [--target local | --target ssh --host HOST | --target proxmox-lxc --proxmox HOST --vmid ID] --secret-ref op://VAULT/ITEM/FIELD [--json]
   bimo deploy TEMPLATE --deployment NAME [--target local | --target ssh --host HOST | --target proxmox-lxc --proxmox HOST --vmid ID] --task-file FILE --secret-ref op://VAULT/ITEM/FIELD --public-url URL [--json]
-  bimo deploy parallel-engineering-pod --deployment NAME [--target local | --target ssh --host HOST | --target proxmox-lxc --proxmox HOST --vmid ID] --task-file FILE --secret-ref op://VAULT/ITEM/FIELD --github-secret-ref op://VAULT/ITEM/FIELD --repository ${POD_REPOSITORY} --base-sha SHA --target-branch main [--json]
+  bimo deploy parallel-engineering-pod --deployment NAME [--target local | --target ssh --host HOST | --target proxmox-lxc --proxmox HOST --vmid ID] --task-file FILE --secret-ref op://VAULT/ITEM/FIELD --github-secret-ref op://VAULT/ITEM/FIELD --base-sha SHA [--repository URL] [--target-branch BRANCH] [--json]
   bimo logs --deployment NAME [--target local | --target ssh --host HOST | --target proxmox-lxc --proxmox HOST --vmid ID] [--run ID] [--json] [--follow]
   bimo runs --deployment NAME [--target local | --target ssh --host HOST | --target proxmox-lxc --proxmox HOST --vmid ID] [--json]
   bimo status --deployment NAME [--target local | --target ssh --host HOST | --target proxmox-lxc --proxmox HOST --vmid ID] [--run ID] [--json]

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -275,7 +275,7 @@ if (runtimeCommand[0] === "true") {
         headBranch: envelope.headBranch,
         publication: {
           number: 42,
-          url: "https://github.com/zaycruz/bimo/pull/42",
+          url: envelope.repository.replace(/\.git$/, "") + "/pull/42",
           draft: true,
           created: true,
           headBranch: envelope.headBranch,
@@ -1113,21 +1113,102 @@ test("internal-pod-run rejects a mismatched packaged template before Git or Dock
   assert.match(result.stderr, /template digest does not match/);
 });
 
-test("internal-publish rejects publication bindings outside the fixed repository", async () => {
-  const result = await invoke(["internal-publish"], {
-    input: JSON.stringify({
-      version: 1,
-      runId: "pod-run-1",
-      repository: "https://github.com/attacker/repository.git",
-      targetBranch: "main",
-      baseSha: POD_BASE_SHA,
-      candidateSha: POD_CANDIDATE_SHA,
-      headBranch: "bimo/pod-run-1",
-      token: `github_pat_${"g".repeat(64)}`,
-    }),
-  });
-  assert.equal(result.code, 1);
-  assert.match(result.stderr, /publisher envelope is invalid/);
+test("internal-publish validates the repository and branch shapes, not a fixed repository", async () => {
+  const base = {
+    version: 1,
+    runId: "pod-run-1",
+    repository: "https://github.com/zaycruz/pod-sandbox.git",
+    targetBranch: "main",
+    baseSha: POD_BASE_SHA,
+    candidateSha: POD_CANDIDATE_SHA,
+    headBranch: "bimo/pod-run-1",
+    token: `github_pat_${"g".repeat(64)}`,
+  };
+  for (const [patch, label] of [
+    [{ repository: "git@github.com:zaycruz/bimo.git" }, "ssh URL"],
+    [{ repository: "https://gitlab.com/zaycruz/bimo.git" }, "non-github host"],
+    [{ repository: "https://user:pass@github.com/zaycruz/bimo.git" }, "credentials in URL"],
+    [{ repository: "https://github.com/zaycruz/../bimo.git" }, "traversal in path"],
+    [{ targetBranch: "main..x" }, "double dot in branch"],
+    [{ targetBranch: "my branch" }, "space in branch"],
+    [{ targetBranch: "/main" }, "leading slash in branch"],
+    [{ targetBranch: "main.lock" }, "lock suffix in branch"],
+  ]) {
+    const result = await invoke(["internal-publish"], {
+      input: JSON.stringify({ ...base, ...patch }),
+    });
+    assert.equal(result.code, 1, label);
+    assert.match(result.stderr, /publisher envelope is invalid/, label);
+  }
+});
+
+test("pod deploy accepts an operator-selected repository and target branch", async t => {
+  const tools = await fakeDeployTools(t, { controller: "pod-success" });
+  const args = podDeployArgs(tools.taskFile).flatMap((value, index, all) => (
+    value === "--repository" || value === "--target-branch"
+      ? []
+      : all[index - 1] === "--repository" || all[index - 1] === "--target-branch"
+        ? []
+        : [value]
+  ));
+  args.push("--repository", "https://github.com/zaycruz/pod-sandbox.git",
+    "--target-branch", "develop");
+  const result = await invoke(args, { env: tools.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  const response = JSON.parse(result.stdout);
+  assert.equal(response.repository, "https://github.com/zaycruz/pod-sandbox.git");
+  assert.equal(response.targetBranch, "develop");
+  assert.equal(response.publication.url, "https://github.com/zaycruz/pod-sandbox/pull/42");
+
+  const entries = await readCommandLog(tools.logFile);
+  const computeEnvelope = entries.find(entry => entry.tool === "pod-compute-envelope");
+  const publishEnvelope = entries.find(entry => entry.tool === "pod-publish-envelope");
+  assert.equal(computeEnvelope.repository, "https://github.com/zaycruz/pod-sandbox.git");
+  assert.equal(computeEnvelope.targetBranch, "develop");
+  assert.equal(publishEnvelope.repository, "https://github.com/zaycruz/pod-sandbox.git");
+  assert.equal(publishEnvelope.targetBranch, "develop");
+});
+
+test("pod deploy defaults the repository and target branch when the flags are omitted", async t => {
+  const tools = await fakeDeployTools(t, { controller: "pod-success" });
+  const args = podDeployArgs(tools.taskFile).flatMap((value, index, all) => (
+    value === "--repository" || value === "--target-branch"
+      ? []
+      : all[index - 1] === "--repository" || all[index - 1] === "--target-branch"
+        ? []
+        : [value]
+  ));
+  const result = await invoke(args, { env: tools.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  const response = JSON.parse(result.stdout);
+  assert.equal(response.repository, "https://github.com/zaycruz/bimo.git");
+  assert.equal(response.targetBranch, "main");
+});
+
+test("pod deploy rejects invalid repository URLs and branch names before any Docker work", async () => {
+  const base = [
+    "deploy", "parallel-engineering-pod",
+    "--deployment", "pod-demo",
+    "--host", "example.invalid",
+    "--task-stdin",
+    "--secret-ref", "op://Test/Bimo/openrouter",
+    "--github-secret-ref", "op://Test/Bimo publisher/github",
+    "--base-sha", POD_BASE_SHA,
+  ];
+  for (const [extra, pattern] of [
+    [["--repository", "git@github.com:zaycruz/bimo.git"], /must be an https github\.com repository URL/],
+    [["--repository", "https://gitlab.com/zaycruz/bimo.git"], /must be an https github\.com repository URL/],
+    [["--repository", "https://user:pass@github.com/zaycruz/bimo.git"], /must be an https github\.com repository URL/],
+    [["--target-branch", "my branch"], /not a valid Git branch name/],
+    [["--target-branch", "main..x"], /not a valid Git branch name/],
+    [["--target-branch", "-bad"], /not a valid Git branch name/],
+  ]) {
+    const result = await invoke([...base, ...extra], { input: "Build the test application.\n" });
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, pattern);
+  }
 });
 
 test("deploy rejects image shell syntax before local execution", async () => {


### PR DESCRIPTION
feat: pi agent runtime (second registry entry) (#46)

Add pi (@earendil-works/pi-coding-agent@0.84.3, pinned) as the second
agent-runtime adapter behind the registry seam from #45.

- spawnArgv: pi -p --mode json --no-session, extras stripped, --tools
  allowlist matching the opencode build-agent scope, instructions as an
  @file message arg, openrouter/<rest> mapped to bimo-gateway/<rest>
- spawnEnv: PI_OFFLINE + PI_CODING_AGENT_DIR pointed at a writable copy
- seedConfig: pi writes a settings lock and auth store next to its
  config and the agent root fs is read-only, so the dispatcher seeds the
  baked root-owned /etc/pi/agent into the HOME tmpfs before spawn
  (bounded: no symlinks, regular files, count/size/depth caps)
- createPiDiagnostics: pi can exit 0 on provider failure; errorStatus is
  extracted from turn_end stopReason:error errorMessage 'NNN:' prefix,
  and the handoff check backstops fail-closed behavior
- agentCreateArgs gains --workdir /workspace (pi has no --dir)
- Dockerfile runtime-pi stage; etc/pi config (bimo-gateway provider,
  telemetry/trust off); .dockerignore whitelist

Stock pi has no permission guards (the fleet's stalls came from a local
extension the image does not load), verified by an escalation task that
exited in 8s with no prompts. Integration: react-solo deploy with
--agent-runtime pi through the real credential proxy — role completed,
starter checks and smoke passed, run record carries agentRuntime pi.

Closes #44
291 tests pass.