### PR TITLE
feat: read-scoped clone credential for private pod repositories (#54)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ orientation: verification loop, hard rules, PR flow, and the design docs.
 Node.js 22+. No install step; there is nothing to install.
 
 ```sh
-npm test            # full suite: node --test test/*.test.mjs (271 tests)
+npm test            # full suite: node --test test/*.test.mjs (301 tests)
 for f in bin/bimo src/*.mjs test/*.mjs; do node --check "$f"; done
 npm pack --dry-run  # verify the package manifest and shipped file set
 ```

--- a/README.md
+++ b/README.md
@@ -346,6 +346,12 @@ The Planner, checker, QA, and Testing receipts are advisory model judgments.
 The separate `bimo-repo-v1` profile and source scan are controller-owned
 gates bound to the exact integrated commit.
 
+Compute holds no GitHub authority. The single, optional exception is a
+read-scoped clone credential (`--clone-secret-ref`) for private repositories:
+it reaches only the controller's initial clone through an isolated askpass
+helper, is erased immediately after the clone, and is never visible to
+agents, present in the clone URL, or retained in the cloned repository.
+
 After those gates pass, compute stops. A separate publisher receives the GitHub
 credential, rechecks the allowlisted base and candidate SHAs, pushes the fixed
 `bimo/<run-id>` branch, and opens a draft pull request. It has no Docker
@@ -512,7 +518,10 @@ project with sources under `src/`, baseline tests in `test/*.test.mjs`, and an
 currently expected at the target branch; publication fails closed if the
 branch moves. The two secret references must resolve to separate,
 least-privilege credentials, and the GitHub token must have content and
-pull-request access to the target repository.
+pull-request access to the target repository. Cloning a private repository
+additionally needs `--clone-secret-ref`, a separate read-scoped fine-grained
+token with contents read-only access to that repository; public repositories
+need nothing extra. Publication still uses only `--github-secret-ref`.
 
 Read the pod's structured events using the run ID returned by deploy:
 
@@ -599,7 +608,8 @@ options cannot be mixed. Deploy also accepts exactly one task source
 requires `--deployment` and `--secret-ref`. Sequential workflows also require
 `--public-url`. The pod instead requires `--github-secret-ref` and an immutable
 `--base-sha`; `--repository` and `--target-branch` are optional and default to
-the Bimo repository and `main`.
+the Bimo repository and `main`, and `--clone-secret-ref` is an optional
+read-scoped token used only to clone a private repository.
 
 Optional shared flags are `--account`, `--model`, `--image`, `--agent-runtime`,
 and `--json`; sequential deploys also accept `--port`. `logs` accepts `--run`,

--- a/docs/runtime-contract.md
+++ b/docs/runtime-contract.md
@@ -104,7 +104,9 @@ platform cannot express one, the adapter is not supported.
   run-scoped gateway. It never appears in argv, environment, workflow JSON,
   prompts, logs, or the shared workspace. The adapter's transport must
   preserve this: no credential in an API payload that the platform logs or
-  persists.
+  persists. The compute phase may additionally hold a read-only clone
+  credential, brokered to the initial clone through an isolated askpass
+  helper and erased afterwards; it is never visible to agents.
 - **Deterministic receipts.** Image digests, execution receipts, artifact
   receipts, and verifier evidence are exact-shape, hash-bound values the
   controller validates (`validateArtifactReceipt`,

--- a/src/bimo.mjs
+++ b/src/bimo.mjs
@@ -66,7 +66,7 @@ const WORKFLOW_DEPLOY_OPTIONS = [
 ];
 const POD_DEPLOY_OPTIONS = [
   "--deployment", "--target", "--host", "--proxmox", "--vmid", "--task-file", "--task-stdin",
-  "--secret-ref", "--github-secret-ref", "--repository", "--base-sha", "--target-branch",
+  "--secret-ref", "--github-secret-ref", "--clone-secret-ref", "--repository", "--base-sha", "--target-branch",
 ];
 const ORGANIZE_OPTIONS = [
   "prompt", "agents", "deployment", "target", "proxmox", "host", "vmid",
@@ -78,7 +78,7 @@ const DEPLOY_WORKFLOW_OPTIONS = [
 ];
 const DEPLOY_POD_OPTIONS = [
   "deployment", "target", "proxmox", "host", "vmid", "task-file", "task-stdin",
-  "secret-ref", "github-secret-ref", "account", "repository", "base-sha",
+  "secret-ref", "github-secret-ref", "clone-secret-ref", "account", "repository", "base-sha",
   "target-branch", "model", "image", "agent-runtime", "json",
 ];
 const DEPLOY_OPTIONS = [...new Set([...DEPLOY_WORKFLOW_OPTIONS, ...DEPLOY_POD_OPTIONS])];
@@ -925,6 +925,15 @@ async function resolveGitHubSecret(reference, account) {
   return secret;
 }
 
+async function resolveCloneSecret(reference, account) {
+  if (!SECRET_REF.test(reference ?? "")) {
+    fail("--clone-secret-ref must be a 1Password op:// reference");
+  }
+  const secret = await opRead(reference, account, "--clone-secret-ref");
+  if (!GITHUB_TOKEN.test(secret)) fail("1Password reference did not resolve to a GitHub token");
+  return secret;
+}
+
 async function deploy(template, options) {
   const loaded = await loadTemplate(template);
   const pod = loaded.kind === "engineering-pod";
@@ -978,6 +987,9 @@ async function deploy(template, options) {
     let githubToken = pod
       ? await resolveGitHubSecret(options["github-secret-ref"], options.account)
       : null;
+    let cloneToken = pod && options["clone-secret-ref"]
+      ? await resolveCloneSecret(options["clone-secret-ref"], options.account)
+      : null;
     heartbeat?.setPhase("preparing image");
     const prepared = await prepareImage(deploymentTarget, image, {
       agentRuntime,
@@ -1019,9 +1031,11 @@ async function deploy(template, options) {
         repository,
         baseSha: options["base-sha"],
         targetBranch,
+        cloneToken,
         runId,
       });
       openRouterKey = "";
+      cloneToken = null;
       const controllerName = `bimo-${options.deployment}-controller`;
       const compute = await targetExecute(deploymentTarget, [
         "docker", "run", "--pull=never", "--rm", "-i",
@@ -1542,7 +1556,7 @@ async function internalPodRun(options) {
   exactOptions(options, ["host-root", "local-home"]);
   const envelope = await readJsonEnvelope(128 * 1024, [
     "version", "template", "templateDigest", "deployment", "task", "key", "model", "agentRuntime", "image",
-    "repository", "baseSha", "targetBranch", "runId",
+    "repository", "baseSha", "targetBranch", "cloneToken", "runId",
   ], "pod controller");
   if (envelope.version !== 1 || !NAME.test(envelope.deployment ?? "")
       || !controllerHostRootIsValid(options["host-root"], envelope.deployment, options["local-home"])
@@ -1555,6 +1569,7 @@ async function internalPodRun(options) {
       || !AGENT_RUNTIME_NAMES.includes(envelope.agentRuntime)
       || !SHA256.test(envelope.image ?? "") || !validPodRepository(envelope.repository)
       || !GIT_SHA.test(envelope.baseSha ?? "") || !validTargetBranch(envelope.targetBranch)
+      || !(envelope.cloneToken === null || GITHUB_TOKEN.test(envelope.cloneToken ?? ""))
       || !RUN_ID.test(envelope.runId ?? "")) {
     fail("pod controller envelope is invalid");
   }
@@ -1572,7 +1587,9 @@ async function internalPodRun(options) {
     worktreesRoot: "/worktrees",
     snapshotsRoot: "/snapshots",
     runId: envelope.runId,
+    cloneCredential: envelope.cloneToken === null ? undefined : { token: envelope.cloneToken },
   });
+  envelope.cloneToken = null;
   await prunePodRuns({ stateRoot: "/state", keepTerminalRuns: 20 });
   const store = await createPodRunStore({
     stateRoot: "/state",
@@ -2606,7 +2623,7 @@ function usage() {
   bimo organize -p PROMPT [-n 1|2|3] --deployment NAME [--target local | --target ssh --host HOST | --target proxmox-lxc --proxmox HOST --vmid ID] --secret-ref op://VAULT/ITEM/FIELD [--json]
   bimo -p PROMPT [-n 1|2|3] --deployment NAME [--target local | --target ssh --host HOST | --target proxmox-lxc --proxmox HOST --vmid ID] --secret-ref op://VAULT/ITEM/FIELD [--json]
   bimo deploy TEMPLATE --deployment NAME [--target local | --target ssh --host HOST | --target proxmox-lxc --proxmox HOST --vmid ID] --task-file FILE --secret-ref op://VAULT/ITEM/FIELD --public-url URL [--json]
-  bimo deploy parallel-engineering-pod --deployment NAME [--target local | --target ssh --host HOST | --target proxmox-lxc --proxmox HOST --vmid ID] --task-file FILE --secret-ref op://VAULT/ITEM/FIELD --github-secret-ref op://VAULT/ITEM/FIELD --base-sha SHA [--repository URL] [--target-branch BRANCH] [--json]
+  bimo deploy parallel-engineering-pod --deployment NAME [--target local | --target ssh --host HOST | --target proxmox-lxc --proxmox HOST --vmid ID] --task-file FILE --secret-ref op://VAULT/ITEM/FIELD --github-secret-ref op://VAULT/ITEM/FIELD --base-sha SHA [--clone-secret-ref op://VAULT/ITEM/FIELD] [--repository URL] [--target-branch BRANCH] [--json]
   bimo logs --deployment NAME [--target local | --target ssh --host HOST | --target proxmox-lxc --proxmox HOST --vmid ID] [--run ID] [--json] [--follow]
   bimo runs --deployment NAME [--target local | --target ssh --host HOST | --target proxmox-lxc --proxmox HOST --vmid ID] [--json]
   bimo status --deployment NAME [--target local | --target ssh --host HOST | --target proxmox-lxc --proxmox HOST --vmid ID] [--run ID] [--json]

--- a/src/git-runtime.mjs
+++ b/src/git-runtime.mjs
@@ -13,6 +13,7 @@ import {
   rename,
   rm,
   rmdir,
+  writeFile,
 } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -39,6 +40,8 @@ const MAX_SCAN_BLOB_BYTES = 16 * 1024 * 1024;
 const MAX_INSPECT_FILE_BYTES = 32 * 1024 * 1024;
 const MAX_REACHABLE_COMMITS = 100;
 const MAX_REACHABLE_TREE_ENTRIES = 200_000;
+const CLONE_TOKEN = /^(?:github_pat_[A-Za-z0-9_]{20,}|gh[psoru]_[A-Za-z0-9]{20,})$/u;
+const ASKPASS_PROGRAM = path.resolve(import.meta.dirname, "..", "bin", "bimo-git-askpass");
 const SECRET_PATTERNS = Object.freeze([
   /-----BEGIN (?:ENCRYPTED |RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----/u,
   /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/u,
@@ -424,6 +427,7 @@ export class GitRuntime {
   #bareRoot;
   #branchHeads = new Map();
   #cloneSource;
+  #cloneToken = null;
   #closed = false;
   #command;
   #environment;
@@ -450,6 +454,7 @@ export class GitRuntime {
     allowedRepositories,
     allowedWriteRoots,
     cloneSource,
+    cloneCredential,
     allowLocalRepository = false,
     gitRoot,
     snapshotsRoot,
@@ -533,6 +538,16 @@ export class GitRuntime {
         fail("invalid local cloneSource");
       }
       this.#cloneSource = cloneSource;
+    }
+    if (cloneCredential !== undefined) {
+      if (allowLocalRepository) fail("cloneCredential is not allowed with allowLocalRepository");
+      if (!isPlainObject(cloneCredential)
+          || Object.keys(cloneCredential).join("\0") !== "token"
+          || !CLONE_TOKEN.test(cloneCredential.token ?? "")) {
+        fail("cloneCredential must contain exactly one GitHub token");
+      }
+      this.#cloneToken = cloneCredential.token;
+      Object.freeze(cloneCredential);
     }
     const currentUid = typeof process.getuid === "function" ? process.getuid() : 0;
     const currentGid = typeof process.getgid === "function" ? process.getgid() : 0;
@@ -704,6 +719,46 @@ export class GitRuntime {
     return runRoot;
   }
 
+  async #createCloneCredential(deadlineAt) {
+    const program = await lstat(ASKPASS_PROGRAM).catch(() => null);
+    if (!program?.isFile() || program.isSymbolicLink()
+        || (program.mode & 0o100) === 0 || (program.mode & 0o022) !== 0) {
+      fail("baked askpass program is invalid");
+    }
+    const token = this.#cloneToken;
+    const tokenBytes = Buffer.byteLength(`${token}\n`);
+    const directory = await checked(deadlineAt, () => mkdtemp(path.join(this.#gitRoot, "clone-credential-")));
+    const tokenFile = path.join(directory, "token");
+    let cleaned = false;
+    const cleanup = async () => {
+      if (cleaned) return;
+      cleaned = true;
+      try {
+        if (await lstat(tokenFile).catch(() => null)) {
+          await writeFile(tokenFile, Buffer.alloc(tokenBytes), { mode: 0o600 });
+        }
+      } finally {
+        await rm(directory, { recursive: true, force: true });
+      }
+    };
+    try {
+      await checked(deadlineAt, () => chmod(directory, 0o700));
+      await checked(deadlineAt, () => writeFile(tokenFile, `${token}\n`, { flag: "wx", mode: 0o600 }));
+      await checked(deadlineAt, () => chmod(tokenFile, 0o600));
+    } catch (error) {
+      await cleanup().catch(() => {});
+      throw error;
+    }
+    return Object.freeze({
+      environment: Object.freeze({
+        GIT_ASKPASS: ASKPASS_PROGRAM,
+        GIT_ASKPASS_REQUIRE: "force",
+        BIMO_GIT_TOKEN_FILE: tokenFile,
+      }),
+      cleanup,
+    });
+  }
+
   async prepareAssignment({ repository, baseRevision, targetBranch, deadlineAt }) {
     requireDeadline(deadlineAt);
     if (this.#prepared !== undefined) fail("assignment is already prepared");
@@ -717,11 +772,27 @@ export class GitRuntime {
     await this.#claimRunDirectory(this.#snapshotsRoot, "snapshot", deadlineAt);
     this.#snapshotsRunOwned = true;
     const source = this.#cloneSource ?? canonical;
-    await this.#run([
-      "-c", "http.followRedirects=false",
-      "-c", `protocol.file.allow=${this.#allowLocalRepository ? "always" : "never"}`,
-      "clone", "--bare", "--no-tags", "--", source, this.#bareRoot,
-    ], { deadlineAt, cwd: this.#gitRoot });
+    let cloneEnvironment;
+    let cloneCredentialCleanup;
+    if (this.#cloneToken !== null) {
+      const credential = await this.#createCloneCredential(deadlineAt);
+      cloneEnvironment = credential.environment;
+      cloneCredentialCleanup = credential.cleanup;
+    }
+    try {
+      await this.#run([
+        "-c", "http.followRedirects=false",
+        "-c", `protocol.file.allow=${this.#allowLocalRepository ? "always" : "never"}`,
+        "clone", "--bare", "--no-tags", "--", source, this.#bareRoot,
+      ], {
+        deadlineAt,
+        cwd: this.#gitRoot,
+        ...(cloneEnvironment === undefined ? {} : { environment: cloneEnvironment }),
+      });
+    } finally {
+      if (cloneCredentialCleanup !== undefined) await cloneCredentialCleanup();
+    }
+    this.#cloneToken = null;
     await checked(deadlineAt, () => chmod(this.#bareRoot, 0o700));
     const bareMetadata = await checked(deadlineAt, () => lstat(this.#bareRoot));
     const resolvedGitRoot = await checked(deadlineAt, () => realpath(this.#gitRoot));
@@ -1923,6 +1994,7 @@ export class GitRuntime {
 
   async close({ retainForPublication = false, deadlineAt } = {}) {
     if (this.#closed) return;
+    this.#cloneToken = null;
     if (typeof retainForPublication !== "boolean") fail("retainForPublication must be a boolean");
     const cleanupDeadline = Number.isSafeInteger(deadlineAt) && deadlineAt > Date.now()
       ? deadlineAt

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -1103,6 +1103,7 @@ test("internal-pod-run rejects a mismatched packaged template before Git or Dock
     repository: "https://github.com/zaycruz/bimo.git",
     baseSha: POD_BASE_SHA,
     targetBranch: "main",
+    cloneToken: null,
     runId: "pod-run-1",
   };
   const result = await invoke([
@@ -1111,6 +1112,37 @@ test("internal-pod-run rejects a mismatched packaged template before Git or Dock
   ], { input: JSON.stringify(envelope) });
   assert.equal(result.code, 1);
   assert.match(result.stderr, /template digest does not match/);
+});
+
+test("internal-pod-run validates the clone credential envelope field", async () => {
+  const envelope = {
+    version: 1,
+    template: "parallel-engineering-pod",
+    templateDigest: "0".repeat(64),
+    deployment: "pod-demo",
+    task: "Implement the fixed pod.",
+    key: `sk-or-v1-${"k".repeat(32)}`,
+    model: "openrouter/deepseek/deepseek-v4-flash",
+    agentRuntime: "opencode",
+    image: LOCAL_IMAGE_ID,
+    repository: "https://github.com/zaycruz/bimo.git",
+    baseSha: POD_BASE_SHA,
+    targetBranch: "main",
+    runId: "pod-run-1",
+  };
+  for (const [patch, pattern, label] of [
+    [{}, /pod controller envelope has an invalid shape/, "missing cloneToken"],
+    [{ cloneToken: "not-a-token" }, /pod controller envelope is invalid/, "malformed cloneToken"],
+    [{ cloneToken: 42 }, /pod controller envelope is invalid/, "non-string cloneToken"],
+  ]) {
+    const candidate = { ...envelope, ...patch };
+    const result = await invoke([
+      "internal-pod-run",
+      "--host-root", "/var/lib/bimo/deployments/pod-demo",
+    ], { input: JSON.stringify(candidate) });
+    assert.equal(result.code, 1, label);
+    assert.match(result.stderr, pattern, label);
+  }
 });
 
 test("internal-publish validates the repository and branch shapes, not a fixed repository", async () => {
@@ -1209,6 +1241,51 @@ test("pod deploy rejects invalid repository URLs and branch names before any Doc
     assert.equal(result.code, 1);
     assert.match(result.stderr, pattern);
   }
+});
+
+test("pod deploy brokers an optional read-scoped clone credential into the compute envelope", async t => {
+  const tools = await fakeDeployTools(t, { controller: "pod-success" });
+  const result = await invoke([
+    ...podDeployArgs(tools.taskFile),
+    "--clone-secret-ref", "op://Test/Bimo clone/github",
+  ], { env: tools.env });
+  assert.equal(result.code, 0, result.stderr);
+
+  const entries = await readCommandLog(tools.logFile);
+  const computeEnvelope = entries.find(entry => entry.tool === "pod-compute-envelope");
+  assert.ok(computeEnvelope.fields.includes("cloneToken"));
+  const cloneIndex = entries.findIndex(entry => entry.tool === "op"
+    && entry.reference === "op://Test/Bimo clone/github");
+  assert.ok(cloneIndex >= 0 && cloneIndex < entries.indexOf(computeEnvelope));
+  const serializedLog = JSON.stringify(entries);
+  assert.equal(serializedLog.includes(`github_pat_${"g".repeat(64)}`), false);
+});
+
+test("pod deploy rejects an invalid clone secret reference before any Docker work", async t => {
+  const tools = await fakeDeployTools(t);
+  for (const [reference, pattern] of [
+    ["not-an-op-reference", /--clone-secret-ref must be a 1Password op:\/\/ reference/],
+    ["op://Test/Bimo/openrouter", /did not resolve to a GitHub token/],
+  ]) {
+    const result = await invoke([
+      ...podDeployArgs(tools.taskFile),
+      "--clone-secret-ref", reference,
+    ], { env: tools.env });
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, pattern);
+  }
+  const entries = await readCommandLog(tools.logFile);
+  assert.equal(entries.some(entry => entry.tool === "ssh"), false);
+});
+
+test("workflow deploys reject the pod-only clone secret flag", async t => {
+  const tools = await fakeDeployTools(t);
+  const result = await invoke([
+    ...deployArgs(tools.taskFile),
+    "--clone-secret-ref", "op://Test/Bimo clone/github",
+  ], { env: tools.env });
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /unknown option: --clone-secret-ref/);
 });
 
 test("deploy rejects image shell syntax before local execution", async () => {
@@ -1358,7 +1435,7 @@ test("pod deploy computes without GitHub authority then publishes one exact draf
   const computeEnvelope = entries.find(entry => entry.tool === "pod-compute-envelope");
   const publishEnvelope = entries.find(entry => entry.tool === "pod-publish-envelope");
   assert.deepEqual(computeEnvelope.fields, [
-    "agentRuntime", "baseSha", "deployment", "image", "key", "model", "repository", "runId",
+    "agentRuntime", "baseSha", "cloneToken", "deployment", "image", "key", "model", "repository", "runId",
     "targetBranch", "task", "template", "templateDigest", "version",
   ]);
   assert.deepEqual(publishEnvelope.fields, [

--- a/test/git-runtime.test.mjs
+++ b/test/git-runtime.test.mjs
@@ -774,3 +774,143 @@ test("aborts an injected Git command at the absolute deadline and waits for sett
   assert.ok(Date.now() - startedAt < 1_000);
   await runtime.close({ deadlineAt: futureDeadline() });
 });
+
+test("validates the clone credential shape at construction", async (t) => {
+  const temporary = await mkdtemp(path.join(os.tmpdir(), "bimo-git-clone-cred-"));
+  t.after(() => rm(temporary, { recursive: true, force: true }));
+  const base = {
+    allowedRepositories: [REPOSITORY],
+    gitRoot: path.join(temporary, "controller"),
+    snapshotsRoot: path.join(temporary, "snapshots"),
+    worktreesRoot: path.join(temporary, "worktrees"),
+    runId: "run-1",
+    allowedWriteRoots: {
+      "engineering-a": ["src"],
+      "engineering-b": ["templates"],
+      "qa-tests": ["test"],
+    },
+  };
+  const token = `github_pat_${"c".repeat(64)}`;
+  for (const cloneCredential of [
+    token,
+    {},
+    { token: "not-a-token" },
+    { token, extra: true },
+    { token: `ghp_${"c".repeat(64)}`, other: token },
+  ]) {
+    assert.throws(() => new GitRuntime({ ...base, cloneCredential }), /cloneCredential/);
+  }
+  assert.throws(() => new GitRuntime({
+    ...base,
+    cloneSource: pathToFileURL(temporary).href,
+    allowLocalRepository: true,
+    cloneCredential: { token },
+  }), /cloneCredential is not allowed with allowLocalRepository/);
+  const runtime = new GitRuntime({ ...base, cloneCredential: { token } });
+  await runtime.close({ deadlineAt: futureDeadline() });
+});
+
+test("brokers the clone credential through askpass only for the clone", async (t) => {
+  const temporary = await mkdtemp(path.join(os.tmpdir(), "bimo-git-clone-cred-"));
+  t.after(() => rm(temporary, { recursive: true, force: true }));
+  const token = `github_pat_${"c".repeat(64)}`;
+  const baseSha = "a".repeat(40);
+  const bareRoot = path.join(temporary, "controller", "repository.git");
+  const calls = [];
+  let tokenFile = null;
+  let tokenFileContent = null;
+  const runner = async (command, args, options = {}) => {
+    calls.push({ command, args, env: options.env ?? {} });
+    if (args.includes("clone")) {
+      tokenFile = options.env?.BIMO_GIT_TOKEN_FILE ?? null;
+      tokenFileContent = tokenFile === null ? null : await readFile(tokenFile, "utf8");
+      await mkdir(bareRoot, { recursive: true, mode: 0o700 });
+      return { stdout: Buffer.alloc(0), stderr: Buffer.alloc(0), exitCode: 0 };
+    }
+    if (args.includes("--show-object-format")) {
+      return { stdout: Buffer.from("sha1\n"), stderr: Buffer.alloc(0), exitCode: 0 };
+    }
+    if (args.includes("rev-parse")) {
+      return { stdout: Buffer.from(`${baseSha}\n`), stderr: Buffer.alloc(0), exitCode: 0 };
+    }
+    return { stdout: Buffer.alloc(0), stderr: Buffer.alloc(0), exitCode: 0 };
+  };
+  const runtime = new GitRuntime({
+    allowedRepositories: [REPOSITORY],
+    gitRoot: path.join(temporary, "controller"),
+    snapshotsRoot: path.join(temporary, "snapshots"),
+    worktreesRoot: path.join(temporary, "worktrees"),
+    runId: "run-1",
+    allowedWriteRoots: {
+      "engineering-a": ["src"],
+      "engineering-b": ["templates"],
+      "qa-tests": ["test"],
+    },
+    runner,
+    cloneCredential: { token },
+  });
+  const prepared = await runtime.prepareAssignment({
+    repository: REPOSITORY,
+    baseRevision: baseSha,
+    targetBranch: "main",
+    deadlineAt: futureDeadline(),
+  });
+  assert.equal(prepared.baseSha, baseSha);
+
+  const cloneCall = calls.find(call => call.args.includes("clone"));
+  assert.ok(cloneCall, "clone was not run");
+  assert.equal(cloneCall.args[cloneCall.args.indexOf("--") + 1], REPOSITORY);
+  assert.equal(JSON.stringify(cloneCall.args).includes(token), false);
+  assert.equal(cloneCall.env.GIT_ASKPASS_REQUIRE, "force");
+  assert.match(cloneCall.env.GIT_ASKPASS, /bin\/bimo-git-askpass$/u);
+  assert.ok(tokenFile, "clone call did not receive a token file");
+  assert.equal(tokenFileContent, `${token}\n`);
+  await assert.rejects(lstat(tokenFile), { code: "ENOENT" });
+  await assert.rejects(lstat(path.dirname(tokenFile)), { code: "ENOENT" });
+
+  for (const call of calls.filter(entry => !entry.args.includes("clone"))) {
+    assert.equal(call.env.GIT_ASKPASS, "/bin/false");
+    assert.equal(Object.hasOwn(call.env, "GIT_ASKPASS_REQUIRE"), false);
+    assert.equal(Object.hasOwn(call.env, "BIMO_GIT_TOKEN_FILE"), false);
+    assert.equal(JSON.stringify(call.env).includes(token), false);
+  }
+  await runtime.close({ deadlineAt: futureDeadline() });
+});
+
+test("removes the clone credential when the clone fails", async (t) => {
+  const temporary = await mkdtemp(path.join(os.tmpdir(), "bimo-git-clone-cred-"));
+  t.after(() => rm(temporary, { recursive: true, force: true }));
+  const token = `github_pat_${"c".repeat(64)}`;
+  let tokenFile = null;
+  const runner = async (command, args, options = {}) => {
+    if (args.includes("clone")) {
+      tokenFile = options.env?.BIMO_GIT_TOKEN_FILE ?? null;
+      throw new Error("clone failed");
+    }
+    return { stdout: Buffer.alloc(0), stderr: Buffer.alloc(0), exitCode: 0 };
+  };
+  const runtime = new GitRuntime({
+    allowedRepositories: [REPOSITORY],
+    gitRoot: path.join(temporary, "controller"),
+    snapshotsRoot: path.join(temporary, "snapshots"),
+    worktreesRoot: path.join(temporary, "worktrees"),
+    runId: "run-1",
+    allowedWriteRoots: {
+      "engineering-a": ["src"],
+      "engineering-b": ["templates"],
+      "qa-tests": ["test"],
+    },
+    runner,
+    cloneCredential: { token },
+  });
+  await assert.rejects(runtime.prepareAssignment({
+    repository: REPOSITORY,
+    baseRevision: "a".repeat(40),
+    targetBranch: "main",
+    deadlineAt: futureDeadline(),
+  }), /clone failed/);
+  assert.ok(tokenFile, "clone call did not receive a token file");
+  await assert.rejects(lstat(tokenFile), { code: "ENOENT" });
+  await assert.rejects(lstat(path.dirname(tokenFile)), { code: "ENOENT" });
+  await runtime.close({ deadlineAt: futureDeadline() });
+});


### PR DESCRIPTION
## Summary

- New optional `--clone-secret-ref` on `bimo deploy parallel-engineering-pod`: a read-scoped GitHub token (fine-grained PAT, contents:read) resolved from 1Password.
- The token rides the pod controller envelope (`cloneToken`, always present, null when unused — exact-shape rule kept) and is brokered to the bare `git clone` only via the existing askpass program: 0600 token file under the claimed git root, `GIT_ASKPASS_REQUIRE=force`, zeroed and deleted right after the clone (also on failure), in-memory copy dropped after clone and on close.
- Agents never observe the credential: it never appears in argv, the clone URL, agent container env, or logs. The bare repo keeps the clean canonical remote URL.
- Publish phase unchanged — still uses only `--github-secret-ref`. Public-repo flow is byte-for-byte unchanged (same argv, same env).

Closes #54.

## Verification

- `npm test`: 301 tests, 0 fail (+7 new: constructor validation, clone-env scoping + cleanup on success and failure, CLI/envelope validation, happy-path pod deploy with the flag, rejection for workflow templates)
- `node --check` on bin/src/test: clean
- `npm pack --dry-run`: 62 files
- README pod section + runtime-contract invariant updated